### PR TITLE
Update Japanese Doc of Eeschema

### DIFF
--- a/src/eeschema/po/ja.po
+++ b/src/eeschema/po/ja.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Eeschema-ja\n"
 "POT-Creation-Date: 2015-10-21 20:10+0900\n"
-"PO-Revision-Date: 2015-09-13 09:48+0200\n"
+"PO-Revision-Date: 2015-10-22 03:48+0900\n"
 "Last-Translator: starfort <starfort@nifty.com>\n"
 "Language-Team: kicad.jp <kicad@kicad.jp>\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.4\n"
+"X-Generator: Poedit 1.8.6\n"
 
 # PR1:07102015 proofreading - chapter1
 # PR2:07122015 proofreading - chapter2,3
@@ -175,15 +175,11 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_introduction.adoc:31
-#, fuzzy
-#| msgid ""
-#| "Design rules check (DRC) for the automatic control of incorrect and "
-#| "missing connections"
 msgid ""
 "Electrical rules check (ERC) for the automatic control of incorrect and "
 "missing connections"
 msgstr ""
-"誤接続、未接続の自動的な検出を行うエレクトリック・ルール・チェッカ (ERC)"
+"誤接続、未接続の自動的な検出を行うエレクトリカル・ルール・チェック (ERC)"
 
 #. type: Plain text
 #: eeschema_introduction.adoc:32
@@ -283,10 +279,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:13
-#, fuzzy
-#| msgid ""
-#| "The suported output formats are POSTSCRIPT, HPGL, SVG and DXF. You can as "
-#| "well directly print to your printer."
 msgid ""
 "The suported output formats are Postscript, PDF, SVG, DXF and HPGL. You can "
 "also directly print to your printer."
@@ -302,10 +294,9 @@ msgstr "出図（プロット）の共通コマンド"
 
 #. type: Labeled list
 #: eeschema_plot_and_print.adoc:17
-#, fuzzy, no-wrap
-#| msgid "Plot Current"
+#, no-wrap
 msgid "Plot Current Page"
-msgstr "“現在のページをプロット”"
+msgstr "現在のページをプロット"
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:18
@@ -316,20 +307,14 @@ msgstr "現在のシートのみプロットします。"
 #: eeschema_plot_and_print.adoc:19
 #, no-wrap
 msgid "Plot All Pages"
-msgstr ""
+msgstr "全てのページをプロット"
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:21
-#, fuzzy
-#| msgid ""
-#| "“Plot All” allows you to plot the whole hierarchy (one print file is "
-#| "generated for each sheet)."
 msgid ""
 "allows you to plot the whole hierarchy (one print file is generated for each "
 "sheet)."
-msgstr ""
-"“全てのページをプロット” は全階層をプロットします（各シート毎に印刷ファイルを"
-"１つ生成する）。"
+msgstr "全階層をプロットします（各シート毎に印刷ファイルを１つ生成する）。"
 
 #. type: Title ===
 #: eeschema_plot_and_print.adoc:23
@@ -341,6 +326,7 @@ msgstr "Postscript のプロット"
 #: eeschema_plot_and_print.adoc:26
 msgid "This command allows you to create PostScript files."
 msgstr ""
+"“回路図のプロット” 内のフォーマットで PostScript オプションを指定します。"
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:28
@@ -353,13 +339,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:34
-#, fuzzy
-#| msgid ""
-#| "The file name is the sheet name with an extension .ps. You can disable "
-#| "the option “print title block”. This is useful if you want to create a "
-#| "postscript file for encapsulation (format .eps) often used to insert a "
-#| "diagram in a word processing software. The message window displays the "
-#| "file names created."
 msgid ""
 "The file name is the sheet name with an extension .ps. You can disable the "
 "option \"Plot border and title block\". This is useful if you want to create "
@@ -375,31 +354,23 @@ msgstr ""
 
 #. type: Title ===
 #: eeschema_plot_and_print.adoc:36
-#, fuzzy, no-wrap
-#| msgid "Plot in DXF"
+#, no-wrap
 msgid "Plot in PDF"
-msgstr "DXF のプロット"
+msgstr "PDF のプロット"
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:39
-#, fuzzy
-#| msgid "image:images/en/dev-chain.png[dev-chain_png]"
 msgid "image:images/eeschema_plot_pdf.png[eeschema_plot_pdf.png]"
-msgstr "image:images/ja/dev-chain.png[dev-chain_png]"
+msgstr "image:images/eeschema_plot_pdf.png[eeschema_plot_pdf.png]"
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:42
-#, fuzzy
-#| msgid ""
-#| "Allows you to create plot files using the format DXF. This option is "
-#| "available via the icon image:images/icons/plot_svg.png[icons/"
-#| "plot_svg_png].  The file name is the sheet name with an extension .dxf."
 msgid ""
 "Allows you to create plot files using the format PDF.  The file name is the "
 "sheet name with an extension .pdf."
 msgstr ""
-"“回路図のプロット” 内のフォーマットで DXF オプションを指定します。ファイル名"
-"はシート名に拡張子 .dxf を付加したものになります。"
+"“回路図のプロット” 内のフォーマットで PDF オプションを指定します。ファイル名"
+"はシート名に拡張子 .pdf を付加したものになります。"
 
 #. type: Title ===
 #: eeschema_plot_and_print.adoc:44
@@ -418,11 +389,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:50
-#, fuzzy
-#| msgid ""
-#| "Allows you to create plot files using the vectored format SVG. This "
-#| "option is available via the icon image:images/icons/plot_svg.png[icons/"
-#| "plot_svg_png].  The file name is the sheet name with an extension .svg."
 msgid ""
 "Allows you to create plot files using the vectored format SVG.  The file "
 "name is the sheet name with an extension .svg."
@@ -447,11 +413,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:58
-#, fuzzy
-#| msgid ""
-#| "Allows you to create plot files using the format DXF. This option is "
-#| "available via the icon image:images/icons/plot_svg.png[icons/"
-#| "plot_svg_png].  The file name is the sheet name with an extension .dxf."
 msgid ""
 "Allows you to create plot files using the format DXF.  The file name is the "
 "sheet name with an extension .dxf."
@@ -467,11 +428,6 @@ msgstr "HPGL のプロット"
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:64
-#, fuzzy
-#| msgid ""
-#| "This command allows you to create an HPGL file. This option is available "
-#| "via the icon image:images/icons/plot_hpg.png[icons/plot_hpg_png].  In "
-#| "this format you can define."
 msgid ""
 "This command allows you to create an HPGL file.  In this format you can "
 "define:"
@@ -481,29 +437,25 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:66
-#, fuzzy
-#| msgid "Sheet size."
 msgid "Page size."
-msgstr "シートサイズ。"
+msgstr "ページ サイズ。"
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:67
 msgid "Origin."
-msgstr ""
+msgstr "原点。"
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:68
 msgid "Pen width (in mm)."
-msgstr ""
+msgstr "ペン幅 (mm単位)。"
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:70
-#, fuzzy
-#| msgid "The plotter setup dialog window looks like the following."
 msgid "The plotter setup dialog window looks like the following:"
 msgstr ""
 "以下は “回路図のプロット” ダイアログです。（上部メニューバーから、ファイル -"
-"> 出図 -> 出図を選択します。）"
+"> 出図 -> 出図を選択します。）:"
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:72
@@ -546,12 +498,6 @@ msgstr "オフセット調整"
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:90
-#, fuzzy
-#| msgid ""
-#| "For all standard dimensions, you can adjust the offsets to center the "
-#| "drawing as accurately as possible. Because plotters have an origin point "
-#| "at the center or at the lower left corner of the sheet, it is necessary "
-#| "to be able to introduce an offset, in order to plot properly."
 msgid ""
 "For all standard dimensions, you can adjust the offsets to center the "
 "drawing as accurately as possible. Because plotters have an origin point at "
@@ -564,8 +510,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:92
-#, fuzzy
-#| msgid "Generally speaking."
 msgid "Generally speaking:"
 msgstr "一般的に言えることですが、"
 
@@ -580,10 +524,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:97
-#, fuzzy
-#| msgid ""
-#| "For plotters having their origin point at the lower left corner of the "
-#| "sheet the offset must be set equal to 0."
 msgid ""
 "For plotters having their origin point at the lower left corner of the sheet "
 "the offset must be set to 0."
@@ -593,8 +533,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:99
-#, fuzzy
-#| msgid "To set an offset."
 msgid "To set an offset:"
 msgstr "オフセットを設定するには次のことを行います。"
 
@@ -641,10 +579,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:116
-#, fuzzy
-#| msgid ""
-#| "The “Print sheet reference and title block” option enables or disables "
-#| "sheet references and title block."
 msgid ""
 "The \"Print sheet reference and title block\" option enables or disables "
 "sheet references and title block."
@@ -654,11 +588,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_plot_and_print.adoc:120
-#, fuzzy
-#| msgid ""
-#| "The “Print in black and white” option sets printing in monochrome. This "
-#| "option is generally necessary if you use a black and white laser printer, "
-#| "because colors are printed into half-tones that are often not so readable."
 msgid ""
 "The \"Print in black and white\" option sets printing in monochrome. This "
 "option is generally necessary if you use a black and white laser printer, "
@@ -696,9 +625,6 @@ msgstr "コンポーネントのリスト。"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:13
-#, fuzzy
-#| msgid ""
-#| "The list of connections between components, called equip-potential nets."
 msgid "The list of connections between components, called equi-potential nets."
 msgstr "等電位リストと呼ばれる、コンポーネント間の接続のリスト。"
 
@@ -822,10 +748,8 @@ msgstr "ネットリストの例"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:60
-#, fuzzy
-#| msgid "You can see below a schematic design using the PSPICE library."
 msgid "You can see below a schematic design using the PSPICE library:"
-msgstr "PSpice ライブラリを使用した回路設計は以下を参照して下さい。"
+msgstr "PSpice ライブラリを使用した回路設計は以下を参照して下さい。:"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:62
@@ -838,10 +762,8 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:64
-#, fuzzy
-#| msgid "Example of a PCBNEW netlist file."
 msgid "Example of a PCBNEW netlist file:"
-msgstr "Pcbnew ネットリストファイルの例です。"
+msgstr "Pcbnew ネットリストファイルの例です。:"
 
 #. type: delimited block -
 #: eeschema_create_a_netlist.adoc:124
@@ -967,10 +889,8 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:127
-#, fuzzy
-#| msgid "In PSPICE format, the netlist is as follows."
 msgid "In PSPICE format, the netlist is as follows:"
-msgstr "PSpice フォーマットでは，ネットリストは次のようになります。"
+msgstr "PSpice フォーマットでは，ネットリストは次のようになります。:"
 
 #. type: delimited block -
 #: eeschema_create_a_netlist.adoc:130
@@ -1066,11 +986,6 @@ msgstr "ネットリスト名の注意事項"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:172
-#, fuzzy
-#| msgid ""
-#| "Many software tools that use netlists do not accept spaces in the "
-#| "component names, pins, equipotentials or others. Systematically avoid "
-#| "spaces in labels, or names and value fields of components or their pins."
 msgid ""
 "Many software tools that use netlists do not accept spaces in the component "
 "names, pins, equi-potential nets or others. Systematically avoid spaces in "
@@ -1083,12 +998,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:177
-#, fuzzy
-#| msgid ""
-#| "In the same way, special characters other than letters and numbers can "
-#| "induce problems. Note that this limitation is not related to Eeschema, "
-#| "but to the netlist formats that can then become not translatable to "
-#| "software that uses netlist files."
 msgid ""
 "In the same way, special characters other than letters and numbers can cause "
 "problems. Note that this limitation is not related to Eeschema, but to the "
@@ -1136,8 +1045,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:193
-#, fuzzy
-#| msgid "Here is a sample using many one line texts and one multi-line text."
 msgid "Here is a sample using many one-line texts and one multi-line text:"
 msgstr "１行テキストを数回使用した例と、複数行テキストを１つ使用した例です。"
 
@@ -1152,10 +1059,8 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:197
-#, fuzzy
-#| msgid "For example: if you type the following text (do not use a label!):"
 msgid "For example, if you type the following text (do not use a label!):"
-msgstr "例えば：次のようなテキストを入力する場合（ラベルを使用しないこと！）:"
+msgstr "例えば、次のようなテキストを入力する場合（ラベルを使用しないこと！）:"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:199
@@ -1265,11 +1170,10 @@ msgstr "ダイアログウィンドウの初期設定"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:239
-#, fuzzy
-#| msgid "You can add a new netlist plug-in via the Add Plugin tab."
 msgid "You can add a new netlist plug-in via the Add Plugin button."
 msgstr ""
-"プラグイン追加タブで、新規ネットリスト・プラグインを追加することが可能です。"
+"プラグイン追加ボタンで、新規ネットリスト・プラグインを追加することが可能で"
+"す。"
 
 # 07072015変更：/ja/へ移動
 #. type: Plain text
@@ -1283,10 +1187,8 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:243
-#, fuzzy
-#| msgid "Here is the plug-in PadsPcb setup window"
 msgid "Here is the plug-in PadsPcb setup window:"
-msgstr "PadsPcb プラグインのセットアップウィンドウです。"
+msgstr "PadsPcb プラグインのセットアップウィンドウです。:"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:245
@@ -1304,10 +1206,8 @@ msgstr "セットアップには以下が必要です:"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:249
-#, fuzzy
-#| msgid "A title (for instance: the name of the netlist format)."
 msgid "A title (for example, the name of the netlist format)."
-msgstr "タイトル（例えば：ネットリスト・フォーマットの名前）。"
+msgstr "タイトル（例えば、ネットリスト フォーマットの名前）。"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:250
@@ -1321,8 +1221,6 @@ msgstr "ネットリスト生成時に、以下のことが行われます:"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:254
-#, fuzzy
-#| msgid "Eeschema creates an intermediate file *.tmp, for instance test.tmp."
 msgid "Eeschema creates an intermediate file *.tmp, for example test.tmp."
 msgstr ""
 "Eeschema は中間ファイル *.tmp を生成します。例えば、test.tmp とします。"
@@ -1341,10 +1239,6 @@ msgstr "コマンドライン・フォーマット"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:261
-#, fuzzy
-#| msgid ""
-#| "Here is an example, using xsltproc.exe as tool to convert .xsl files, and "
-#| "a file netlist_form_pads-pcb.xsl as converter sheet style:"
 msgid ""
 "Here is an example, using xsltproc.exe as a tool to convert .xsl files, and "
 "a file netlist_form_pads-pcb.xsl as converter sheet style:"
@@ -1415,19 +1309,12 @@ msgstr ""
 
 #. type: Title ====
 #: eeschema_create_a_netlist.adoc:286
-#, fuzzy, no-wrap
-#| msgid "Converter and sheet style (plug in)"
+#, no-wrap
 msgid "Converter and sheet style (plug-in)"
 msgstr "コンバーターとシートスタイル（プラグイン）"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:292
-#, fuzzy
-#| msgid ""
-#| "This is a very simple piece of software, because its purpose is only to "
-#| "convert an input text file (the intermediate text file) to an other text "
-#| "file. Moreover, from the intermediate text file, you can create a BOM "
-#| "list."
 msgid ""
 "This is a very simple piece of software, because its purpose is only to "
 "convert an input text file (the intermediate text file) to another text "
@@ -1439,10 +1326,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:295
-#, fuzzy
-#| msgid ""
-#| "When using xsltproc as converter tool only the sheet style will be "
-#| "generated."
 msgid ""
 "When using xsltproc as the converter tool only the sheet style will be "
 "generated."
@@ -1457,10 +1340,6 @@ msgstr "中間ネットリスト・ファイル・フォーマット"
 
 #. type: Plain text
 #: eeschema_create_a_netlist.adoc:301
-#, fuzzy
-#| msgid ""
-#| "See Chapter 14 for more explanations about xslproc, the descriptions of "
-#| "intermediate file format, and some examples of sheet style for converters."
 msgid ""
 "See Chapter 14 for more explanations about xslproc, descriptions of the "
 "intermediate file format, and some examples of sheet style for converters."
@@ -1819,7 +1698,7 @@ msgstr "コンポーネント番号の選択方法を選択します。"
 #: eeschema_general_top_toolbar.adoc:137
 #, no-wrap
 msgid "Electrical Rules Check tool"
-msgstr "エレクトリック・ルール・チェッカ (ERC) ツール"
+msgstr "エレクトリカル・ルール・チェック (ERC) ツール"
 
 #. type: Plain text
 #: eeschema_general_top_toolbar.adoc:142
@@ -1827,8 +1706,8 @@ msgid ""
 "The icon image:images/icons/erc.png[ERC icon] gives access to the electrical "
 "rules check (ERC) tool."
 msgstr ""
-"image:images/icons/erc.png[ERC icon] アイコンで、エレクトリック・ルール・"
-"チェッカ (ERC) ツールを呼出します。"
+"image:images/icons/erc.png[ERC icon] アイコンで、エレクトリカル・ルール・"
+"チェック (ERC) ツールを呼出します。"
 
 #. type: Plain text
 #: eeschema_general_top_toolbar.adoc:145
@@ -1865,7 +1744,7 @@ msgstr "image:images/ja/dialog_erc.png[ERC dialog]"
 #: eeschema_general_top_toolbar.adoc:155
 msgid "Errors are displayed in the Electrical Rules Checker dialog box:"
 msgstr ""
-"エラーはエレクトリック・ルール・チェッカ (ERC) ダイアログボックスに表示されま"
+"エラーはエレクトリカル・ルール・チェック (ERC) ダイアログボックスに表示されま"
 "す："
 
 #. type: Plain text
@@ -1904,7 +1783,7 @@ msgstr "マーカーの削除：全ての ERC エラー／警告マーカーを�
 #. type: Plain text
 #: eeschema_general_top_toolbar.adoc:168
 msgid "Run: to perform an Electrical Rules Check."
-msgstr "実行：エレクトリック・ルール・チェッカを実行する"
+msgstr "実行：エレクトリカル・ルール・チェックを実行する"
 
 #. type: Plain text
 #: eeschema_general_top_toolbar.adoc:169
@@ -2001,42 +1880,34 @@ msgstr ""
 #. type: Plain text
 #: eeschema_general_top_toolbar.adoc:205
 msgid "A useful set of component properties to use for a BOM are:"
-msgstr "部品表 (BOM) で使用されるコンポーネントプロパティは、次のとおりです。:"
+msgstr ""
+"部品表 (BOM) での使用に役立つコンポーネントのプロパティには、以下のものが挙げ"
+"られます。:"
 
 #. type: Plain text
 #: eeschema_general_top_toolbar.adoc:207
-#, fuzzy
-#| msgid "Value – unique name for each part used."
 msgid "Value - unique name for each part used."
-msgstr "定数 – 各使用部品で固有の名前"
+msgstr "定数 – 各部品で使用される固有の名前"
 
 #. type: Plain text
 #: eeschema_general_top_toolbar.adoc:208
-#, fuzzy
-#| msgid "Footprint – either manually entered or back-annotated (see below)."
 msgid "Footprint - either manually entered or back-annotated (see below)."
 msgstr "フットプリント – 手入力、またはバックアノテートされたもの（下図参照）"
 
 #. type: Plain text
 #: eeschema_general_top_toolbar.adoc:209
-#, fuzzy
-#| msgid "Field1 – Manufacturer's name."
 msgid "Field1 - Manufacturer's name."
-msgstr "データシート – 製造業者の提供する部品のデータシート"
+msgstr "フィールド１ – 製造業者名（任意、追加が必要）"
 
 #. type: Plain text
 #: eeschema_general_top_toolbar.adoc:210
-#, fuzzy
-#| msgid "Field2 – Manufacturer's Part Number."
 msgid "Field2 - Manufacturer's Part Number."
-msgstr "Fab. – 製造業者名（オプション）"
+msgstr "フィールド２ – 製造業者の部品番号（任意、追加が必要）"
 
 #. type: Plain text
 #: eeschema_general_top_toolbar.adoc:211
-#, fuzzy
-#| msgid "Field3 – Distributor's Part Number."
 msgid "Field3 - Distributor's Part Number."
-msgstr "Ref. Fab – 製造業者の部品番号（オプション）"
+msgstr "フィールド３ – 販売業者の部品番号（任意、追加が必要）"
 
 #. type: Plain text
 #: eeschema_general_top_toolbar.adoc:213
@@ -2384,14 +2255,10 @@ msgstr "画面上部のアイコンをクリックする （一般コマンド�
 
 #. type: Plain text
 #: eeschema_generic_commands.adoc:12
-#, fuzzy
-#| msgid ""
-#| "Clicking on the icons on the right side of the screen (particular "
-#| "commands or “tools”)."
 msgid ""
 "Clicking on the icons on the right side of the screen (particular commands "
 "or \"tools\")."
-msgstr "画面右側のアイコンをクリックする（特別なコマンド、または “ツール” ）。"
+msgstr "画面右側のアイコンをクリックする（特殊コマンド、または “ツール” ）。"
 
 #. type: Plain text
 #: eeschema_generic_commands.adoc:14
@@ -2411,19 +2278,14 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_generic_commands.adoc:21
-#, fuzzy
-#| msgid ""
-#| "Function keys (F1, F2, F3, F4, Insert and space keys).  Specifically: The "
-#| "“Escape” key often allows the canceling of a command in progress. The "
-#| "“Insert” key allows the duplication of the last element created."
 msgid ""
 "Function keys (F1, F2, F3, F4, Insert and space keys).  Specifically: The "
 "\"Escape\" key often allows the canceling of a command in progress. The "
 "\"Insert\" key allows the duplication of the last element created."
 msgstr ""
-"キーボードのファンクションキー （F1，F2，F3，F4，インサートとスペースキー）。"
-"特に  “ESC” キーは，多くの進行中のコマンドを中断できます。 “Insert” キーは、"
-"最後に作成された要素を複写します。"
+"キーボードのファンクションキー （F1，F2，F3，F4，インサートとスペース "
+"キー）。特に  “ESC” キーは，多くの進行中のコマンドを中断できます。 “Insert” "
+"キーは、最後に作成された要素を複写します。"
 
 #. type: Plain text
 #: eeschema_generic_commands.adoc:23
@@ -2564,8 +2426,6 @@ msgstr "ホットキー"
 
 #. type: Plain text
 #: eeschema_generic_commands.adoc:71
-#, fuzzy
-#| msgid "The “?” key displays the current hotkey list."
 msgid "The \"?\" key displays the current hotkey list."
 msgstr "“?” で現在のホットキーのリストを表示します。"
 
@@ -2851,11 +2711,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_generic_commands.adoc:168
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/save.png[icons/save_png]\n"
-#| "a|\n"
-#| "Save complete (hierarchical) schematic.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/save.png[icons/save_png]\n"
 "|Save complete (hierarchical) schematic.\n"
@@ -3033,7 +2889,7 @@ msgid ""
 "|Electrical rules check (ERC), automatically validate electrical connections.\n"
 msgstr ""
 "|image:images/icons/erc.png[ERC icon]\n"
-"|ERC (エレクトリック・ルール・チェッカ)。自動で電気的接続をチェックする。\n"
+"|ERC (エレクトリカル・ルール・チェック)。自動で電気的接続をチェックする。\n"
 
 #. type: delimited block |
 #: eeschema_generic_commands.adoc:222
@@ -3057,23 +2913,17 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_generic_commands.adoc:228
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/edit_module.png[edit_module icon]\n"
-#| "|Edit module.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/edit_module.png[edit_module icon]\n"
 "|Edit footprint.\n"
 msgstr ""
 "|image:images/icons/edit_module.png[edit_module icon]\n"
-"|フットプリントエディタ\n"
+"|フットプリント エディタ\n"
 
 #. type: delimited block |
 #: eeschema_generic_commands.adoc:231
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/cvpcb.png[run cvpcb icon]\n"
-#| "|Call CvPvb to assign footprints to components.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/cvpcb.png[run cvpcb icon]\n"
 "|Call CvPcb to assign footprints to components.\n"
@@ -3109,18 +2959,13 @@ msgstr "右ツールバー"
 
 #. type: delimited block |
 #: eeschema_generic_commands.adoc:245
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/toolbar_schedit_rightside.png[images/toolbar_schedit_rightside.png]\n"
-#| "a|\n"
-#| "This toolbar contains tools to:\n"
+#, no-wrap
 msgid ""
 "|image:images/toolbar_schedit_rightside.png[images/toolbar_schedit_rightside.png]\n"
 "|This toolbar contains tools to:\n"
 msgstr ""
 "|image:images/toolbar_schedit_rightside.png[images/toolbar_schedit_rightside.png]\n"
-"a|\n"
-"このツールバーは次のツールを含んでいます:\n"
+"|このツールバーは次のツールを含んでいます:\n"
 
 #. type: delimited block |
 #: eeschema_generic_commands.adoc:250
@@ -3138,10 +2983,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_generic_commands.adoc:255
-#, fuzzy
-#| msgid ""
-#| "The detailed use of these tools is described in the chapter “Diagram "
-#| "Creation/Editing”. An outline of their use is given below."
 msgid ""
 "The detailed use of these tools is described in the chapter \"Diagram "
 "Creation/Editing\". An outline of their use is given below."
@@ -3239,12 +3080,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_generic_commands.adoc:290
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/noconn.png[icons/noconn_png]\n"
-#| "|Place a \"no connection\" symbol. These are placed on component pins which\n"
-#| "are not to be connected. This is useful in the ERC function to check if\n"
-#| "pins are intentionally left not connected or are missed.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/noconn.png[icons/noconn_png]\n"
 "|Place a \"No Connect\" flag. These are placed on component pins which\n"
@@ -3286,20 +3122,14 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_generic_commands.adoc:304
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/add_glabel.png[Global label icon]\n"
-#| "a|\n"
-#| "Place a global label. All global labels with the same name are connected, even between\n"
-#| "different sheets.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/add_glabel.png[Global label icon]\n"
 "|Place a global label. All global labels with the same name are connected, even between\n"
 "different sheets.\n"
 msgstr ""
 "|image:images/icons/add_glabel.png[Global label icon]\n"
-"a|\n"
-"グローバルラベルの配置。異なるシート間であっても、全ての\n"
+"|グローバルラベルの配置。異なるシート間であっても、全ての\n"
 "グローバルラベルは接続されます。\n"
 
 #. type: delimited block |
@@ -3326,13 +3156,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_generic_commands.adoc:316
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/import_hierarchical_label.png[icons/import_hierarchical_label_png]\n"
-#| "a|\n"
-#| "Import hierarchical labels from a subsheet. These hierarchical labels must already be\n"
-#| "placed in the subsheet. These are equivalent to pins on a component, and must be connected\n"
-#| "using wires.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/import_hierarchical_label.png[icons/import_hierarchical_label_png]\n"
 "|Import hierarchical labels from a subsheet. These hierarchical labels must already be\n"
@@ -3340,8 +3164,7 @@ msgid ""
 "using wires.\n"
 msgstr ""
 "|image:images/icons/import_hierarchical_label.png[icons/import_hierarchical_label_png]\n"
-"a|\n"
-"シート内の対応する階層ラベルからインポートされた階層ピンを入力。グローバルラベルは\n"
+"|シート内の対応する階層ラベルからインポートされた階層ピンを入力。グローバルラベルは\n"
 "サブシートに配置されていなければなりません。こうして作った階層シンボルは通常の\n"
 "コンポーネントのピン同様、必ずワイヤを接続しなければなりません。\n"
 
@@ -3389,28 +3212,17 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_generic_commands.adoc:332
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/delete.png[icons/cancel_png]\n"
-#| "a|\n"
-#| "Delete selected element.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/delete.png[icons/cancel_png]\n"
 "|Delete selected element.\n"
 msgstr ""
 "|image:images/icons/delete.png[icons/cancel_png]\n"
-"a|\n"
-"アイテム削除。\n"
+"|アイテム削除。\n"
 
 #. type: delimited block |
 #: eeschema_generic_commands.adoc:338
-#, fuzzy, no-wrap
-#| msgid ""
-#| "If several superimposed elements are selected, the priority is given to\n"
-#| "the smallest (in the decreasing priorities: junction, NoConnect, wire,\n"
-#| "bus, text, component). This also applies to hierarchical sheets. Note:\n"
-#| "the “Undelete” function of the general toolbar allows you to cancel last\n"
-#| "deletions.\n"
+#, no-wrap
 msgid ""
 "If several superimposed elements are selected, the priority is given to\n"
 "the smallest (in the decreasing priorities: junction, \"No Connect\", wire,\n"
@@ -3421,8 +3233,9 @@ msgstr ""
 "いくつかの重なり合った要素が選択された場合には、優先順位は一番\n"
 "小さなものから順になります（ジャンクション、非接続シンボル、配線、\n"
 "バス、テキスト、コンポーネントの順）。これは階層シートにも適用されます。\n"
-"注：ジェネラルツールバーの “Undelete” 機能で最後の削除を取り消すことが\n"
+"注：上部ツールバーの “Undo” 機能で最後の削除を取り消すことが\n"
 "できます。\n"
+"\n"
 
 #. type: Title ===
 #: eeschema_generic_commands.adoc:341
@@ -3605,7 +3418,7 @@ msgid ""
 "Validating against a set of rules (<<erc,Electrical Rules Check>>) to detect "
 "errors and omissions."
 msgstr ""
-"回路図の誤りや欠落の検出。 (<<erc,ERC（エレクトリック・ルール・チェッカ）によ"
+"回路図の誤りや欠落の検出。 (<<erc,ERC（エレクトリカル・ルール・チェック）によ"
 "る設計検証>>)"
 
 #. type: Plain text
@@ -3639,11 +3452,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_schematic_creation_and_editing.adoc:31
-#, fuzzy
-#| msgid ""
-#| "A schematic mainly consists of components, wires, labels, junctions, "
-#| "buses and power ports. For clarity in the schematic, you can place purely "
-#| "graphical elements like bus entries, comments, and dotted lines."
 msgid ""
 "A schematic mainly consists of components, wires, labels, junctions, buses "
 "and power ports. For clarity in the schematic, you can place purely "
@@ -3689,11 +3497,6 @@ msgstr "コンポーネントの検索と配置"
 
 #. type: Plain text
 #: eeschema_schematic_creation_and_editing.adoc:50
-#, fuzzy
-#| msgid ""
-#| "To load a component into your schematic you can use the icon image:images/"
-#| "icons/new_component.png[New Component icon].  A dialog box allows you to "
-#| "type the name of the module to load."
 msgid ""
 "To load a component into your schematic you can use the icon image:images/"
 "icons/new_component.png[New Component icon].  A dialog box allows you to "
@@ -3934,10 +3737,9 @@ msgstr "*バス:* バス配線をまとめラベルを用いて接続\n"
 
 #. type: Plain text
 #: eeschema_schematic_creation_and_editing.adoc:137
-#, fuzzy, no-wrap
-#| msgid "*Dotted lines:* for graphic presentation.\n"
+#, no-wrap
 msgid "*Polylines:* for graphic presentation.\n"
-msgstr "*図形ラインかポリゴン:* （画面を見やすくする）グラフィック表現用\n"
+msgstr "*図形ライン, ポリゴン:* （画面を見やすくする）グラフィック表現用\n"
 
 #. type: Plain text
 #: eeschema_schematic_creation_and_editing.adoc:138
@@ -3971,10 +3773,9 @@ msgstr "*テキスト:* コメントとアノテーション用\n"
 
 #. type: Plain text
 #: eeschema_schematic_creation_and_editing.adoc:143
-#, fuzzy, no-wrap
-#| msgid "*“No Connection” symbols:* to terminate a pin that does not need any connection.\n"
+#, no-wrap
 msgid "*\"No Connect\" flags:* to terminate a pin that does not need any connection.\n"
-msgstr "*“空き端子” フラグ:* 接続する必要のないピンを終端\n"
+msgstr "*“空き端子” フラグ:* 接続する必要のないピンを終端。\n"
 
 #. type: Plain text
 #: eeschema_schematic_creation_and_editing.adoc:144
@@ -4282,16 +4083,12 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_schematic_creation_and_editing.adoc:259
-#, fuzzy
-#| msgid ""
-#| "More precisely, the corresponding members are connected together : PCA0, "
-#| "ADR0 are connected, (as same as PCA1 and ADR1… PCA7 and ADR7)."
 msgid ""
 "More precisely, the corresponding members are connected together : PCA0, "
 "ADR0 are connected, (as same as PCA1 and ADR1 ... PCA7 and ADR7)."
 msgstr ""
 "より正確に言うならば、バスを構成する対応するメンバ同士が接続されます。 : 例え"
-"ば、PCA0 とADR0が接続されています。（同様に、PCA1 と ADR1，…， PCA7 と ADR7）"
+"ば、PCA0 とADR0が接続されています。（同様に、PCA1 と ADR1 … PCA7 と ADR7）"
 
 #. type: Plain text
 #: eeschema_schematic_creation_and_editing.adoc:262
@@ -4429,7 +4226,7 @@ msgstr ""
 #: eeschema_schematic_creation_and_editing.adoc:313
 #, no-wrap
 msgid "\"No Connect\" flag"
-msgstr ""
+msgstr "“空き端子” フラグ"
 
 #. type: Plain text
 #: eeschema_schematic_creation_and_editing.adoc:318
@@ -4443,12 +4240,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_schematic_creation_and_editing.adoc:323
-#, fuzzy
-#| msgid ""
-#| "If pins must really remain unconnected, it is necessary to place a No-"
-#| "Connection symbol (tool image:images/icons/noconn.png[No connection "
-#| "icon])  on these pins. These symbols do not have any influence on the "
-#| "generated netlists."
 msgid ""
 "If pins must really remain unconnected, it is necessary to place a \"No "
 "Connect\" flag (tool image:images/icons/noconn.png[No connection icon])  on "
@@ -4473,13 +4264,6 @@ msgstr "テキストコメント"
 
 #. type: Plain text
 #: eeschema_schematic_creation_and_editing.adoc:337
-#, fuzzy
-#| msgid ""
-#| "It can be useful (to aid in understanding the schematic) to place "
-#| "annotations such as text fields and frames. Text fields (tool image:"
-#| "images/icons/add_text.png[])  and dotted lines (tool image:images/icons/"
-#| "add_dashed_line.png[])  are intended for this use, contrary to labels and "
-#| "wires, which are connection elements."
 msgid ""
 "It can be useful (to aid in understanding the schematic) to place "
 "annotations such as text fields and frames. Text fields (tool image:images/"
@@ -4619,8 +4403,7 @@ msgstr ""
 
 #. type: Title ==
 #: eeschema_libedit_complements.adoc:3
-#, fuzzy, no-wrap
-#| msgid "LibEdit – Complements"
+#, no-wrap
 msgid "LibEdit - Complements"
 msgstr "コンポーネント・ライブラリ・エディタ – 補足"
 
@@ -4751,11 +4534,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_libedit_complements.adoc:57
-#, fuzzy
-#| msgid ""
-#| "A component can have aliases, i.e. equivalent names. This allows you to "
-#| "considerably reduce the number of components that need to be created (for "
-#| "example, a 74LS00 can have aliases such as 74000, 74HC00, 74HCT00…)."
 msgid ""
 "A component can have aliases, i.e. equivalent names. This allows you to "
 "considerably reduce the number of components that need to be created (for "
@@ -5019,10 +4797,6 @@ msgstr "CMOS TTL ：ロジックファミリ"
 
 #. type: Plain text
 #: eeschema_libedit_complements.adoc:149
-#, fuzzy
-#| msgid ""
-#| "AND2 NOR3 XOR2 INV… for the gates (AND2 = 2 inputs AND gate, NOR3 = 3 "
-#| "inputs NOR gate)."
 msgid ""
 "AND2 NOR3 XOR2 INV... for the gates (AND2 = 2 inputs AND gate, NOR3 = 3 "
 "inputs NOR gate)."
@@ -5037,10 +4811,8 @@ msgstr "JKFF DFF… ：JK あるいはD フリップフロップ"
 
 #. type: Plain text
 #: eeschema_libedit_complements.adoc:151
-#, fuzzy
-#| msgid "ADC, DAC, MUX…"
 msgid "ADC, DAC, MUX..."
-msgstr "ADC, DAC, MUX…OpenCol："
+msgstr "ADC, DAC, MUX…"
 
 # 07102015：変更（原文誤り）
 #. type: Plain text
@@ -5245,22 +5017,12 @@ msgstr ""
 
 #. type: Title ==
 #: eeschema_design_verification_with_erc.adoc:3
-#, fuzzy, no-wrap
-#| msgid "Design verification with electrical rules check"
+#, no-wrap
 msgid "Design verification with Electrical Rules Check"
-msgstr "ERC（エレクトリック・ルール・チェッカ）による設計検証"
+msgstr "ERC（エレクトリカル・ルール・チェック）による設計検証"
 
 #. type: Plain text
 #: eeschema_design_verification_with_erc.adoc:14
-#, fuzzy
-#| msgid ""
-#| "The Electrical Rules Check (ERC) tool performs an automatic check of your "
-#| "schematic. The ERC checks for any errors in your sheet, such as "
-#| "unconnected pins, unconnected hierarchical symbols, shorted outputs, etc. "
-#| "Naturally, an automatic check is not infallible, and the software that "
-#| "make it possible to detect all design errors is not yet 100% complete. "
-#| "Such a check is very useful, because it allows you to detect many "
-#| "oversights and small errors."
 msgid ""
 "The Electrical Rules Check (ERC) tool performs an automatic check of your "
 "schematic. The ERC checks for any errors in your sheet, such as unconnected "
@@ -5269,7 +5031,7 @@ msgid ""
 "to detect all design errors is not yet 100% complete. Such a check is very "
 "useful, because it allows you to detect many oversights and small errors."
 msgstr ""
-"ERC （エレクトリック・ルール・チェッカ）ツールは回路図の自動チェックを実行し"
+"ERC （エレクトリカル・ルール・チェック）ツールは回路図の自動チェックを実行し"
 "ます。ERC は、未接続ピン、未接続の階層シンボル、出力のショートなどのような"
 "シート内のすべてのエラーをチェックします。当然ながら、自動チェックは絶対確実"
 "なものではありませんし、設計エラーを検出可能なソフトウェアは１００％完全では"
@@ -5278,12 +5040,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_design_verification_with_erc.adoc:19
-#, fuzzy
-#| msgid ""
-#| "In fact all detected errors must be checked and then corrected before "
-#| "proceeding as normal. The quality of the ERC is directly related to the "
-#| "care taken in declaring electrical pin properties during library "
-#| "creation. ERC output is reported as “errors” or “warnings”."
 msgid ""
 "In fact all detected errors must be checked and then corrected before "
 "proceeding as normal. The quality of the ERC is directly related to the care "
@@ -5312,10 +5068,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_design_verification_with_erc.adoc:30
-#, fuzzy
-#| msgid ""
-#| "Warnings are placed on the schematic elements rising an ERC error (pins, "
-#| "or labels)."
 msgid ""
 "Warnings are placed on the schematic elements raising an ERC error (pins or "
 "labels)."
@@ -5325,23 +5077,15 @@ msgstr ""
 
 #. type: delimited block =
 #: eeschema_design_verification_with_erc.adoc:35
-#, fuzzy
-#| msgid ""
-#| "In this dialog window, when clicking on an error message you can jump to "
-#| "the corresponding marker in schematic."
 msgid ""
 "In this dialog window, when clicking on an error message you can jump to the "
 "corresponding marker in the schematic."
 msgstr ""
-"“エレクトリック・ルール・チェッカ (ERC)” ダイアログ内でエラーメッセージをク"
+"“エレクトリカル・ルール・チェック (ERC)” ダイアログ内でエラーメッセージをク"
 "リックすると、回路図内の対応するマーカーに移動できます。"
 
 #. type: delimited block =
 #: eeschema_design_verification_with_erc.adoc:37
-#, fuzzy
-#| msgid ""
-#| "In the schematic right click on a marker to access the corresponding "
-#| "diagnostic message."
 msgid ""
 "In the schematic right-click on a marker to access the corresponding "
 "diagnostic message."
@@ -5397,10 +5141,6 @@ msgstr "診断結果の表示"
 
 #. type: Plain text
 #: eeschema_design_verification_with_erc.adoc:58
-#, fuzzy
-#| msgid ""
-#| "By right clicking on a marker the pop menu allows to access the ERC "
-#| "marker diagnostic window."
 msgid ""
 "By right-clicking on a marker the pop-up menu allows you to access the ERC "
 "marker diagnostic window."
@@ -5437,12 +5177,6 @@ msgstr "電源ピンと電源フラグ"
 
 #. type: Plain text
 #: eeschema_design_verification_with_erc.adoc:73
-#, fuzzy
-#| msgid ""
-#| "It is common to have an error or a warning on power pins, even though all "
-#| "seems normal. See example above. This happens because, in most designs, "
-#| "the power is provided by connectors, that are not power sources (like "
-#| "regulator output, which is declared as Power out)."
 msgid ""
 "It is common to have an error or a warning on power pins, even though all "
 "seems normal. See example above. This happens because, in most designs, the "
@@ -5465,16 +5199,12 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_design_verification_with_erc.adoc:79
-#, fuzzy
-#| msgid ""
-#| "To avoid this warning you have to place a “PWR_FLAG” on such a power "
-#| "port. Take a look at the following example."
 msgid ""
 "To avoid this warning you have to place a \"PWR_FLAG\" on such a power port. "
 "Take a look at the following example:"
 msgstr ""
 "この警告を避けるには、そのような電源ポートに “PWR_FLAG” を配置しなければなり"
-"ません．次の例を参照して下さい。"
+"ません．次の例を参照して下さい。:"
 
 #. type: Plain text
 #: eeschema_design_verification_with_erc.adoc:81
@@ -5529,16 +5259,12 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_design_verification_with_erc.adoc:99
-#, fuzzy
-#| msgid ""
-#| "Rules can be changed by clicking on the desired square of the matrix, "
-#| "causing it to cycle through the choices : normal, warning, error."
 msgid ""
 "Rules can be changed by clicking on the desired square of the matrix, "
 "causing it to cycle through the choices: normal, warning, error."
 msgstr ""
 "マトリクス内の変更したい四角をクリックすると，ノーマル，警告，エラーの選択が"
-"サイクリックに切り替わり、ルールの変更が可能です。"
+"順番に切り替わり、ルールの変更が可能です。"
 
 #. type: Title ===
 #: eeschema_design_verification_with_erc.adoc:101
@@ -6060,18 +5786,13 @@ msgstr "グラフィカルな型式 (design) （ライン、円、テキスト�
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:30
-#, fuzzy
-#| msgid ""
-#| "Pins which have both graphic properties (line, clock, inverted, low level "
-#| "active, etc ) and electrical properties (input, output, bidirectional, "
-#| "etc.) used by the E lectrical R ules C heck (ERC) tool."
 msgid ""
 "Pins which have both graphic properties (line, clock, inverted, low level "
 "active, etc ) and electrical properties (input, output, bidirectional, etc.) "
 "used by the Electrical Rules Check (ERC) tool."
 msgstr ""
 "ピンは、図形的なプロパティ（線（通常のピン）、クロックピン、反転ピン、Low レ"
-"ベルアクティブピンなど）と ERC（エレクトリック・ルール・チェッカ）ツールが使"
+"ベルアクティブピンなど）と ERC（エレクトリカル・ルール・チェック）ツールが使"
 "用する電気的なプロパティ（入力、出力、双方向など）の両方を持っています。"
 
 #. type: Plain text
@@ -6085,11 +5806,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:35
-#, fuzzy
-#| msgid ""
-#| "Aliases used to associate a common component such as a 7400 with all of "
-#| "it's derivatives such as 74LS00, 74HC00, and 7437. All of these aliases "
-#| "share the same library component."
 msgid ""
 "Aliases used to associate a common component such as a 7400 with all of its "
 "derivatives such as 74LS00, 74HC00, and 7437. All of these aliases share the "
@@ -6138,10 +5854,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:49
-#, fuzzy
-#| msgid ""
-#| "Adding an alias if other components have the same symbol and pin out or "
-#| "removing one if the component has been created from an other component."
 msgid ""
 "Adding an alias if other components have the same symbol and pin out or "
 "removing one if the component has been created from another component."
@@ -6152,16 +5864,12 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:51
-#, fuzzy
-#| msgid ""
-#| "Adding optional fields such the name of the footprint used by the PCB "
-#| "design software and/or defining their visibility."
 msgid ""
 "Adding optional fields such as the name of the footprint used by the PCB "
 "design software and/or defining their visibility."
 msgstr ""
-"PCB 設計ソフトウェアが使用するフットプリント名のように補助的なフィールドを追"
-"加し、それらの可視性を定義する。"
+"PCB 設計ソフトウェアが使用するフットプリント名のような補助的フィールドを追加"
+"し、それらの可視性を定義する。"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:53
@@ -6461,11 +6169,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:153
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/toolbar_libedit_part.png[images/toolbar_libedit_part.png]\n"
-#| "|Select the unit to display. The drop down control will be disable if\n"
-#| "the current component is not derived from multiple units.\n"
+#, no-wrap
 msgid ""
 "|image:images/toolbar_libedit_part.png[images/toolbar_libedit_part.png]\n"
 "|Select the unit to display. The drop down control will be disabled if\n"
@@ -6517,11 +6221,6 @@ msgstr "エレメント・ツールバー"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:172
-#, fuzzy
-#| msgid ""
-#| "The vertical toolbar typically located on the right hand side of the main "
-#| "window allows you to place all of the elements required to design a "
-#| "component. The table below defines each tool bar button."
 msgid ""
 "The vertical toolbar typically located on the right hand side of the main "
 "window allows you to place all of the elements required to design a "
@@ -6533,15 +6232,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:182
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/cursor.png[icons/cursor_png]\n"
-#| "|Select tool. Right clicking with the select tool opens the context menu\n"
-#| "for the object under the cursor. Left clicking with the select tool\n"
-#| "displays the attributes of the object under the cursor in the message\n"
-#| "panel at the bottom of the main window. Left double-click with the\n"
-#| "select tool will open the properties dialog for the object under the\n"
-#| "cursor.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/cursor.png[icons/cursor_png]\n"
 "|Select tool. Right-clicking with the select tool opens the context menu\n"
@@ -6560,10 +6251,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:185
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/pin.png[icons/pin_png]\n"
-#| "|Pin tool. Left click to add a new pin.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/pin.png[icons/pin_png]\n"
 "|Pin tool. Left-click to add a new pin.\n"
@@ -6573,10 +6261,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:188
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/add_text.png[icons/add_text_png]\n"
-#| "|Graphical text tool. Left click to add a new graphical text item.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/add_text.png[icons/add_text_png]\n"
 "|Graphical text tool. Left-click to add a new graphical text item.\n"
@@ -6586,12 +6271,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:193
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/add_rectangle.png[icons/add_rectangle_png]\n"
-#| "|Rectangle tool. Left click to begin drawing the first corner of a\n"
-#| "graphical rectangle. Left click again to place the opposite corner of\n"
-#| "the rectangle.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/add_rectangle.png[icons/add_rectangle_png]\n"
 "|Rectangle tool. Left-click to begin drawing the first corner of a\n"
@@ -6604,11 +6284,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:197
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/add_circle.png[icons/add_circle_png]\n"
-#| "|Circle tool. Left click to begin drawing a new graphical circle from\n"
-#| "the center. Left click again to define the radius of the cicle.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/add_circle.png[icons/add_circle_png]\n"
 "|Circle tool. Left-click to begin drawing a new graphical circle from\n"
@@ -6620,12 +6296,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:202
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/add_arc.png[icons/add_arc_png]\n"
-#| "|Arc tool. Left click to begin drawing a new graphical arc item from the\n"
-#| "center. Left click again to define the first arc end point. Left click\n"
-#| "again to defint the second arc end point.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/add_arc.png[icons/add_arc_png]\n"
 "|Arc tool. Left-click to begin drawing a new graphical arc item from the\n"
@@ -6639,12 +6310,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:207
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/add_polygon.png[icons/add_polygon_png]\n"
-#| "|Polygon tool. Left click to begin drawing a new graphical polygon item\n"
-#| "in the current component. Left click for each addition polygon line.\n"
-#| "Left double click to complete the polygon.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/add_polygon.png[icons/add_polygon_png]\n"
 "|Polygon tool. Left-click to begin drawing a new graphical polygon item\n"
@@ -6658,10 +6324,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:210
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/anchor.png[icons/anchor_png]\n"
-#| "|Anchor tool. Left click to set the anchor position of the component.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/anchor.png[icons/anchor_png]\n"
 "|Anchor tool. Left-click to set the anchor position of the component.\n"
@@ -6681,10 +6344,7 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:219
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/delete.png[icons/delete_png]\n"
-#| "|Delete tool. Left click to delete an object from the current component.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/delete.png[icons/delete_png]\n"
 "|Delete tool. Left-click to delete an object from the current component.\n"
@@ -6757,13 +6417,6 @@ msgstr "ライブラリの選択および保守"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:251
-#, fuzzy
-#| msgid ""
-#| "The selection of the current library is possible via the image:images/"
-#| "icons/library.png[icons/library_png] which shows you all available "
-#| "libraries and allows you to select one.  When a component is loaded or "
-#| "saved, it will be put in this library. The library name of component is "
-#| "the contents of it's value field."
 msgid ""
 "The selection of the current library is possible via the image:images/icons/"
 "library.png[icons/library_png] which shows you all available libraries and "
@@ -6779,9 +6432,6 @@ msgstr ""
 
 #. type: delimited block =
 #: eeschema_component_library_editor.adoc:255
-#, fuzzy
-#| msgid ""
-#| "You must load a library in Eeschema, in order to access it's contents."
 msgid "You must load a library in Eeschema, in order to access its contents."
 msgstr ""
 "ライブラリに含まれるコンポーネントの読込み／保存を行うためには、Eeschema でラ"
@@ -6815,12 +6465,6 @@ msgstr "コンポーネントの選択および保存"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:270
-#, fuzzy
-#| msgid ""
-#| "When you edit a component you are not really working on the component in "
-#| "its library but on a copy of it in the computer's memory. Any edit action "
-#| "can undone easily. A component may be loaded from a local library or from "
-#| "an existing component."
 msgid ""
 "When you edit a component you are not really working on the component in its "
 "library but on a copy of it in the computer's memory. Any edit action can be "
@@ -6853,15 +6497,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:287
-#, fuzzy
-#| msgid ""
-#| "If a component selected by it's alias, the name of the loaded component "
-#| "is displayed on the window title bar instead of selected alias. The list "
-#| "of component aliases is always loaded with each component and can be "
-#| "edited. You can create a new component by selecting an alias of the "
-#| "current component from the image:images/toolbar_libedit_alias.png[images/"
-#| "étoolbar_libedit_alias.png].  The first item in the alias list is the "
-#| "root name of the component."
 msgid ""
 "If a component is selected by its alias, the name of the loaded component is "
 "displayed on the window title bar instead of the selected alias. The list of "
@@ -6899,10 +6534,6 @@ msgstr "コンポーネントの保存"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:300
-#, fuzzy
-#| msgid ""
-#| "After modification, a component can be saved in the current library or in "
-#| "a new library or exported to a backup file."
 msgid ""
 "After modification, a component can be saved in the current library, in a "
 "new library, or exported to a backup file."
@@ -6962,13 +6593,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:334
-#, fuzzy
-#| msgid ""
-#| "Click the image:images/icons/export.png[icons/export_png] to create a "
-#| "file containing only the current component. This file will be a standard "
-#| "library file which will contains only one component.  This file can be "
-#| "used to import the component into another library. In fact the create new "
-#| "library command and the export command are basically identical."
 msgid ""
 "Click the image:images/icons/export.png[icons/export_png] to create a file "
 "containing only the current component. This file will be a standard library "
@@ -7082,17 +6706,6 @@ msgstr "新規コンポーネントの作成"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:379
-#, fuzzy
-#| msgid ""
-#| "A new component can be created clicking the image:images/icons/"
-#| "new_component.png[icons/new_component_png].  You will be asked for a "
-#| "component name (this name is used as default value for the value field in "
-#| "the schematic editor), the reference designator (U, IC, R...), the number "
-#| "of units per package (for example a 7400 is made of 4 units per package) "
-#| "and if an alternate body style (sometimes referred to as DeMorgan) is "
-#| "desired. If the reference designator field is left empty, it will default "
-#| "to “U”. These properties changed later, but it is preferable to set them "
-#| "correctly at the creation of the component."
 msgid ""
 "A new component can be created clicking the image:images/icons/new_component."
 "png[icons/new_component_png].  You will be asked for a component name (this "
@@ -7149,11 +6762,6 @@ msgstr "他のコンポーネントからコンポーネントを作成"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:393
-#, fuzzy
-#| msgid ""
-#| "Often, the component that you want to make is similar to one already in a "
-#| "component library. In this case it is easy to load and modify an already "
-#| "existing component."
 msgid ""
 "Often, the component that you want to make is similar to one already in a "
 "component library. In this case it is easy to load and modify an existing "
@@ -7170,12 +6778,6 @@ msgstr "出発点として使うコンポーネントを読み込みます。"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:400
-#, fuzzy
-#| msgid ""
-#| "Click on the image:images/icons/copycomponent.png[icons/"
-#| "copycomponent_png] or modify its name by right click on the value field "
-#| "and editing the text.  If you chose to duplicate the current component, "
-#| "you will be prompted for a new component name."
 msgid ""
 "Click on the image:images/icons/copycomponent.png[icons/copycomponent_png] "
 "or modify its name by right-click on the value field and editing the text.  "
@@ -7184,7 +6786,9 @@ msgid ""
 msgstr ""
 "アイコン image:images/icons/copycomponent.png[icons/copycomponent_png] をク"
 "リックするかまたは名前を右クリックしてコンポーネント名のテキストを編集し、そ"
-"の名前を変更します。"
+"の名前を変更します。もし、あなたが変更しようとした名前が既に使われていた場"
+"合、そのコンポーネントを上書きして新しく作成するコンポーネントと交換するかど"
+"うか確認を求められます。"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:404
@@ -7239,12 +6843,6 @@ msgstr "コンポーネントプロパティの編集"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:424
-#, fuzzy
-#| msgid ""
-#| "Component properties should be carefully set during the component "
-#| "creation or alternatively they are inherited from copied component. To "
-#| "change the component properties, click on the image:images/icons/"
-#| "part_properties.png[icons/part_properties_png] to show the dialog below."
 msgid ""
 "Component properties should be carefully set during the component creation "
 "or alternatively they are inherited from the copied component. To change the "
@@ -7268,15 +6866,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:434
-#, fuzzy
-#| msgid ""
-#| "It is very important to correct set the number of units per package and "
-#| "if the component has an alternate symbolic representation parameters "
-#| "correctly because when pins are edited or created the corresponding pins "
-#| "for each unit will created. If you change the number of units per package "
-#| "after pin creation and editing, there will be additional work introduced "
-#| "to add the new unit pins and symbols. Nevertheless, it is possible to "
-#| "modify these properies at any time."
 msgid ""
 "It is very important to correctly set the number of units per package and if "
 "the component has an alternate symbolic representation parameters correctly "
@@ -7295,16 +6884,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:443
-#, fuzzy
-#| msgid ""
-#| "The graphic options “Show pin number” and “Show pin name” define the "
-#| "visibility of the pin number and pin name text. This text will be visible "
-#| "if the corresponding options are checked. The option “Place pin names "
-#| "inside” defines the pin name position relative to the pin body.  This "
-#| "text will be displayed inside the component outline if the option is "
-#| "checked. In this case the “Pin Name Position Offset” property defines the "
-#| "shift of the text away from the body end of the pin. A value from 30 to "
-#| "40 (in 1/1000 inch) is reasonable."
 msgid ""
 "The graphic options \"Show pin number\" and \"Show pin name\" define the "
 "visibility of the pin number and pin name text. This text will be visible if "
@@ -7325,10 +6904,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:446
-#, fuzzy
-#| msgid ""
-#| "The example below shows a component with the “Place pin name inside” "
-#| "option unchecked. Notice the position of the names and pin numbers."
 msgid ""
 "The example below shows a component with the \"Place pin name inside\" "
 "option unchecked. Notice the position of the names and pin numbers."
@@ -7366,12 +6941,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:462
-#, fuzzy
-#| msgid ""
-#| "To edit the alternate symbol click on the image:images/icons/morgan2."
-#| "png[icons/morgan2_png].  Use the image:images/toolbar_libedit_alias."
-#| "png[images/toolbar_libedit_alias.png] show below to select the unit you "
-#| "wish to edit."
 msgid ""
 "To edit the alternate symbol click on the image:images/icons/morgan2."
 "png[icons/morgan2_png].  Use the image:images/toolbar_libedit_alias."
@@ -7450,13 +7019,6 @@ msgstr "グラフィック要素のメンバーシップ。"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:490
-#, fuzzy
-#| msgid ""
-#| "Each graphic element (line, arc, circle, etc.) can be defined as common "
-#| "to all units and/or body styles or specific to a given unit and/or body "
-#| "style. Element options can be quickly accessed by the right clicking on "
-#| "the element to display the context menu for the selected element. Below "
-#| "is the context menu for a line element."
 msgid ""
 "Each graphic element (line, arc, circle, etc.) can be defined as common to "
 "all units and/or body styles or specific to a given unit and/or body style. "
@@ -7480,16 +7042,12 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:495
-#, fuzzy
-#| msgid ""
-#| "You can also double left click on an element to modify it's properties.  "
-#| "Below is the properties dialog for a polygon element."
 msgid ""
 "You can also double-left-click on an element to modify its properties.  "
 "Below is the properties dialog for a polygon element."
 msgstr ""
-"またこの要素を左ダブルクリックすると要素のプロパティを変更できます。次に円の"
-"プロパティダイアログの例を示します。"
+"またこの要素を左ダブルクリックすると要素のプロパティを変更できます。次に多角"
+"形のプロパティダイアログの例を示します。"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:497
@@ -7516,11 +7074,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:506
-#, fuzzy
-#| msgid ""
-#| "The “Common to all units in component” setting defines if the graphical "
-#| "element is drawn for each unit in component with more than one unit per "
-#| "package or if the graphical element is only drawn for the current unit."
 msgid ""
 "The \"Common to all units in component\" setting defines if the graphical "
 "element is drawn for each unit in component with more than one unit per "
@@ -7532,12 +7085,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:510
-#, fuzzy
-#| msgid ""
-#| "The “Common by all body styles (DeMorgan)” setting defines if the "
-#| "graphical element is drawn for each symbolic representation in components "
-#| "with an alternate body style or if the graphical element is only drawn "
-#| "for the current body style."
 msgid ""
 "The \"Common by all body styles (DeMorgan)\" setting defines if the "
 "graphical element is drawn for each symbolic representation in components "
@@ -7585,13 +7132,6 @@ msgstr "多パーツコンポーネントと代替ボディスタイル"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:531
-#, fuzzy
-#| msgid ""
-#| "Components can have two symbolic representations (a standard symbol and "
-#| "an alternate symbol often referred to as “DeMorgan”) and/or have more "
-#| "than one unit per package (logic gates for example). Some components can "
-#| "have more than one unit per package each with different symbols and pin "
-#| "configurations."
 msgid ""
 "Components can have two symbolic representations (a standard symbol and an "
 "alternate symbol often referred to as \"DeMorgan\") and/or have more than "
@@ -7704,18 +7244,13 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:571
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/100000000000010C000000B26BA7AD80.png[100000000000010C000000B26BA7AD80_png]\n"
-#| "a|\n"
-#| "Unit 3\n"
+#, no-wrap
 msgid ""
 "|image:images/100000000000010C000000B26BA7AD80.png[100000000000010C000000B26BA7AD80_png]\n"
 "|Unit 3\n"
 msgstr ""
 "|image:images/100000000000010C000000B26BA7AD80.png[100000000000010C000000B26BA7AD80_png]\n"
-"a|\n"
-"パーツ 3\n"
+"|パーツ 3\n"
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:574
@@ -7735,12 +7270,6 @@ msgstr "グラフィックシンボル要素"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:584
-#, fuzzy
-#| msgid ""
-#| "Shown below are properties for a graphic body element. From the relay "
-#| "example above, the three units have different symbolic representations.  "
-#| "Therefore, each unit was created separately and the graphical body "
-#| "elements must have the “Common to all units in component” disabled."
 msgid ""
 "Shown below are properties for a graphic body element. From the relay "
 "example above, the three units have different symbolic representations.  "
@@ -7769,14 +7298,6 @@ msgstr "ピンの作成および編集"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:597
-#, fuzzy
-#| msgid ""
-#| "You can click on the image:images/icons/pin.png[icons/pin_png] to create "
-#| "and insert a pin. The editing of all pin properties is done by double-"
-#| "clicking on the pin or right-clicking on the pin to open the pin context "
-#| "menu. Pins must be created carefully, because any error will have "
-#| "consequences on the PCB design. Any pin already placed can be edited, "
-#| "deleted, and / or moved."
 msgid ""
 "You can click on the image:images/icons/pin.png[icons/pin_png] to create and "
 "insert a pin. The editing of all pin properties is done by double-clicking "
@@ -7799,14 +7320,6 @@ msgstr "ピンの概要"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:607
-#, fuzzy
-#| msgid ""
-#| "A pin is defined by it's graphical representation, it's name and it's "
-#| "“number”. The pin's “number” is defined by a set of 4 letters and / or "
-#| "numbers. For the electronic rules check (ERC) tool to be useful, the "
-#| "pin's “electrical” type (input, output, tri-state...) must also be "
-#| "defined correctly. If this type is not defined properly, the schematic "
-#| "ERC check results may be invalid."
 msgid ""
 "A pin is defined by its graphical representation, its name and its \"number"
 "\". The pin's \"number\" is defined by a set of 4 letters and / or numbers. "
@@ -7817,7 +7330,7 @@ msgid ""
 msgstr ""
 "ピンはその形状（長さ、グラフィックな外観）、名前および “番号“ で定義されま"
 "す。“番号“ は４つまでの英文字または数字で定義されます。（番号は常に数字である"
-"とは限りません。）ERC （エレクトリック・ルール・チェッカ） ツールを機能させる"
+"とは限りません。）ERC （エレクトリカル・ルール・チェック） ツールを機能させる"
 "ためには、“電気的“ タイプ（入力、出力、３ステート...）も定義されていなければ"
 "なりません。このタイプが正しく定義されていない場合には、ERC チェックが非効率"
 "になります。（正しい結果を表示できません。）"
@@ -7835,19 +7348,14 @@ msgstr "ピン名とピン番号に空白（半角スペース (space) ）を使
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:614
-#, fuzzy
-#| msgid ""
-#| "To define a pin name with an inverted signal (overline) use the tilde “~” "
-#| "character. The next “~” character will turn off the overline. For example "
-#| "~FO~O would display FO O."
 msgid ""
 "To define a pin name with an inverted signal (overline) use the `~` (tilde) "
 "character. The next `~` character will turn off the overline.  For example `"
 "\\~FO~O` would display [overline]#FO# O."
 msgstr ""
-"反転信号（上付き横線（overline）付信号）のピン名はチルダ記号 “~“ で始めます。"
-"次の “~“ 記号は上付き横線（overline）を無効にします。例えば、~FO~O は "
-"FO(overline付) O(overline無) と表示されます。"
+"反転信号（上付き横線（overline）付信号）のピン名はチルダ記号 `~` で始めます。"
+"次の `~` 記号は上付き横線（overline）を無効にします。例えば、 `\\~FO~O` は "
+"[overline]#FO# O と表示されます。"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:616
@@ -7860,17 +7368,11 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:617
-#, fuzzy
-#| msgid "Pin names starting with “#”, are reserved for power port symbols."
 msgid "Pin names starting with `#`, are reserved for power port symbols."
-msgstr "“#” で始まるピン名は電源ポート用に予約されています。"
+msgstr "`#` で始まるピン名は電源ポート用に予約されています。"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:619
-#, fuzzy
-#| msgid ""
-#| "A pin “number” consists of 1 to 4 letters and/ or numbers. 1,2,..9999 are "
-#| "valid numbers. A1, B3, Anod, Gnd, Wi r e, etc. are also valid."
 msgid ""
 "A pin \"number\" consists of 1 to 4 letters and/ or numbers. 1,2,..9999 are "
 "valid numbers. A1, B3, Anod, Gnd, Wire, etc. are also valid."
@@ -7881,8 +7383,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:620
-#, fuzzy
-#| msgid "Duplicate pin “numbers” cannot exist in a component."
 msgid "Duplicate pin \"numbers\" cannot exist in a component."
 msgstr "コンポーネントで重複したピン “番号“ を使うことはできません。"
 
@@ -7952,11 +7452,6 @@ msgstr "ピンの形状（グラフィックスタイル）"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:643
-#, fuzzy
-#| msgid ""
-#| "You can see on the figure below the different pin graphical styles. The "
-#| "choice of graphic styles does not have any influence on the pin's "
-#| "electrical type."
 msgid ""
 "Shown in the figure below are the different pin graphical styles. The choice "
 "of graphic styles does not have any influence on the pin's electrical type."
@@ -8117,14 +7612,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:705
-#, fuzzy
-#| msgid ""
-#| "A component can have two symbolic representations (representation known "
-#| "as “DeMorgan”) and can be made up of more than one unit as in the case of "
-#| "components with logic gates. For certain components, you may want several "
-#| "different graphic elements and pins. Like the relay sample shown in "
-#| "section 11.7.1, a relay can be represented three distinct units: a coil, "
-#| "switch contact 1, and switch contact 2."
 msgid ""
 "A component can have two symbolic representations (representation known as "
 "\"DeMorgan\") and can be made up of more than one unit as in the case of "
@@ -8197,18 +7684,6 @@ msgstr "コンポーネントのフィールド"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:741
-#, fuzzy
-#| msgid ""
-#| "All library components are defined with four default fields. The "
-#| "reference designator, value, footprint assignment, and documentation file "
-#| "link fields are created whenever a component is created or copied.  Only "
-#| "the reference designator and value fields are required. For existing "
-#| "fields, you can use the context menu commands by right click ing on the "
-#| "pin. Components defined in libraries typically are defined with these "
-#| "four default fields. Additional fields such as vendor, part number, unit "
-#| "cost, etc. can be added to library components but generally this is done "
-#| "in the schematic editor so the additional fields can be applied to all of "
-#| "the components in the schematic."
 msgid ""
 "All library components are defined with four default fields. The reference "
 "designator, value, footprint assignment, and documentation file link fields "
@@ -8239,10 +7714,6 @@ msgstr "コンポーネントフィールドの編集"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:747
-#, fuzzy
-#| msgid ""
-#| "To edit an existing component field, right click on the field text to "
-#| "show the field context menu shown below."
 msgid ""
 "To edit an existing component field, right-click on the field text to show "
 "the field context menu shown below."
@@ -8312,13 +7783,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:773
-#, fuzzy
-#| msgid ""
-#| "The footprint is defined as an absolute footprint using the LIBNAME:"
-#| "FPNAME format where LIBNAME is the name of the footprint library defined "
-#| "in the footprint library table (see the “Footprint Library Table” section "
-#| "in the Pcbnew “Reference Manual”) and FPNAME is the name of the footprint "
-#| "in the library LIBNAME."
 msgid ""
 "The footprint is defined as an absolute footprint using the LIBNAME:FPNAME "
 "format where LIBNAME is the name of the footprint library defined in the "
@@ -8340,14 +7804,6 @@ msgstr "電源ポートシンボル"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:783
-#, fuzzy
-#| msgid ""
-#| "Power symbols are created the same way as normal components. It may be "
-#| "useful to place them in a dedicated library such as power.lib. Power "
-#| "symbols consist of a graphical symbol and a pin of the type “Power "
-#| "Invisible”. Power port symbols are handled like any other component by "
-#| "the schematic capture software. Some precautions are essential. Below is "
-#| "an example of a power +5V symbol."
 msgid ""
 "Power symbols are created the same way as normal components. It may be "
 "useful to place them in a dedicated library such as power.lib. Power symbols "
@@ -8357,10 +7813,10 @@ msgid ""
 "power +5V symbol."
 msgstr ""
 "電源ポートのシンボルは通常のコンポーネントと同様に作成します。Power.lib のよ"
-"うな専用のライブラリにそれらを集めるのが便利かもしれません。それらはグラフィ"
-"カルなシンボル（希望する形状）で構成され、“非表示電源“ タイプのピンです。電源"
+"うな専用のライブラリにそれらを集めると便利かもしれません。それらはグラフィカ"
+"ルなシンボル（希望する形状）で構成され、“非表示電源“ タイプのピンです。電源"
 "ポートのシンボルはこのため回路図入力ソフトウェアで 他のすべてのコンポーネント"
-"のように扱われます。いくつかの基本的な注意事項があります。以下は +5V の電源シ"
+"と同様に扱われます。いくつかの基本的な注意事項があります。以下は +5V の電源シ"
 "ンボルの例です。"
 
 #. type: Plain text
@@ -8379,11 +7835,6 @@ msgstr "以下のステップに従ってシンボルを作成します。:"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:791
-#, fuzzy
-#| msgid ""
-#| "Add a pin of type “Power input” named +5V (important because this name "
-#| "will establish connection to the net +5V), with a pin number of 1 (number "
-#| "of no importance), a length of 0, and a “Line” “Graphic Style”."
 msgid ""
 "Add a pin of type \"Power input\" named +5V (important because this name "
 "will establish connection to the net +5V), with a pin number of 1 (number of "
@@ -8405,20 +7856,11 @@ msgstr "ピン上にシンボルのアンカーを置きます。"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:795
-#, fuzzy
-#| msgid "The component value is +5V."
 msgid "The component value is `+5V`."
-msgstr "コンポーネントの定数を +5V とします。"
+msgstr "コンポーネントの定数を `+5V` とします。"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:800
-#, fuzzy
-#| msgid ""
-#| "The component reference is #+5V. The reference text is no importance "
-#| "except the first character which must be “#” to indicate that the "
-#| "component is a power symbol. By convention, every component in which the "
-#| "reference field starts with a '#' will not appear in the component list "
-#| "or in the netlist and the reference is declared as invisible."
 msgid ""
 "The component reference is `\\#+5V`. The reference text is not important "
 "except the first character which must be `#` to indicate that the component "
@@ -8426,24 +7868,20 @@ msgid ""
 "field starts with a `#` will not appear in the component list or in the "
 "netlist and the reference is declared as invisible."
 msgstr ""
-"コンポーネントのリファレンスを #+5V とします。リファレンスのテキストは、最初"
-"の文字を必ず “#” とします。それ以外の文字は重要ではありません。従来どおり、リ"
-"ファレンスがこのシンボルで始まるすべてのコンポーネントはコンポーネントリスト"
-"にもネットリストのどちらにも現れません。さらに、シンボルのオプションで、リ"
-"ファレンスは非表示として宣言されます。"
+"コンポーネントのリファレンスを `\\#+5V` とします。リファレンスのテキストは、"
+"最初の文字を必ず `#` とします。それ以外の文字は重要ではありません。従来どお"
+"り、リファレンスがこのシンボルで始まるすべてのコンポーネントはコンポーネント"
+"リストにもネットリストのどちらにも現れません。さらに、シンボルのオプション"
+"で、リファレンスは非表示として宣言されます。"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:803
-#, fuzzy
-#| msgid ""
-#| "An easier method to create of a new power port symbol is to use another "
-#| "symbol as model."
 msgid ""
 "An easier method to create a new power port symbol is to use another symbol "
 "as a model:"
 msgstr ""
 "新規の電源ポートシンボルは、他のシンボルを型として使用すると容易にそして速く"
-"作成できます。"
+"作成できます。:"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:805
@@ -8511,13 +7949,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:25
-#, fuzzy
-#| msgid ""
-#| "From the root sheet, you must be able to find all sub-sheets.  "
-#| "Hierarchical schematics management is very easy with Eeschema, thanks to "
-#| "an integrated “hierarchy navigator” accessible via the icon image:images/"
-#| "icons/hierarchy_nav.png[icons/hierarchy_nav_png] of the upper and right "
-#| "toolbar."
 msgid ""
 "From the root sheet, you must be able to find all sub-sheets.  Hierarchical "
 "schematics management is very easy with Eeschema, thanks to an integrated "
@@ -8616,11 +8047,6 @@ msgstr "階層内のナビゲーション"
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:63
-#, fuzzy
-#| msgid ""
-#| "Navigation among sub-sheets It is very easy thanks to the navigator tool "
-#| "accessible via the button image:images/icons/hierarchy_nav.png[icons/"
-#| "hierarchy_nav_png] on the horizontal toolbar."
 msgid ""
 "Navigation among sub-sheets It is very easy thanks to the navigator tool "
 "accessible via the button image:images/icons/hierarchy_nav.png[icons/"
@@ -8641,10 +8067,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:68
-#, fuzzy
-#| msgid ""
-#| "Each sheet is reachable by clicking on its name. For quick access, right "
-#| "click on a sheet name, and choose to enter into sheet."
 msgid ""
 "Each sheet is reachable by clicking on its name. For quick access, right "
 "click on a sheet name, and choose to Enter Sheet."
@@ -8652,31 +8074,22 @@ msgstr "シート名を左ダブルクリックすると、そのシートに移
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:73
-#, fuzzy
-#| msgid ""
-#| "You can quickly reach the root sheet, or a sub-sheet thanks to the tool "
-#| "image:images/icons/hierarchy_nav.png[icons/hierarchy_nav_png] of the "
-#| "right vertical toolbar. After the navigation tool has been selected:"
 msgid ""
 "You can quickly reach the root sheet, or a sub-sheet thanks to the tool "
 "image:images/icons/hierarchy_cursor.png[icons/hierarchy_cursor_png] of the "
 "right toolbar. After the navigation tool has been selected:"
 msgstr ""
-"右ツールバーにある image:images/icons/hierarchy_nav.png[icons/"
-"hierarchy_nav_png] “階層の上下移動” ツールにより、ルートシートあるいはサブ"
+"右ツールバーにある image:images/icons/hierarchy_cursor.png[icons/"
+"hierarchy_cursor_png] “階層の上下移動” ツールにより、ルートシートあるいはサブ"
 "シートに素早く移動可能です。ツールを選択後に以下の操作を行います："
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:75
-#, fuzzy
-#| msgid "Click on a sheet name to selection this sheet."
 msgid "Click on a sheet name to select the sheet."
 msgstr "シート内でシート名を左クリックすると、そのシートに移動します。"
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:76
-#, fuzzy
-#| msgid "Click elsewhere to select the main sheet."
 msgid "Click elsewhere to select the Root sheet."
 msgstr ""
 "サブシートでシート名以外の場所を左クリックすると、上の階層のシートに移動しま"
@@ -8744,8 +8157,6 @@ msgstr "次のことをする必要があります:"
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:106
-#, fuzzy
-#| msgid "Place in the root sheet a hierarchy symbol called “sheet symbol”."
 msgid "Place in the root sheet a hierarchy symbol called \"sheet symbol\"."
 msgstr "“シートシンボル” という階層シンボルをルートシート内に配置します。"
 
@@ -8845,8 +8256,7 @@ msgstr ""
 
 #. type: Title ===
 #: eeschema_hierarchical_schematics.adoc:140
-#, fuzzy, no-wrap
-#| msgid "Connections – hierarchical pins"
+#, no-wrap
 msgid "Connections - hierarchical pins"
 msgstr "接続 － 階層ピン"
 
@@ -8913,10 +8323,6 @@ msgstr "ピンを配置したい階層シンボルをクリックします。"
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:166
-#, fuzzy
-#| msgid ""
-#| "See below an example of the creation of the hierarchical pin called "
-#| "“CONNEXION”."
 msgid ""
 "See below an example of the creation of the hierarchical pin called "
 "\"CONNEXION\"."
@@ -8959,19 +8365,17 @@ msgstr "出力（Output）"
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:177
 msgid "Bidirectional"
-msgstr ""
+msgstr "双方向（Bidirectional）"
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:178
-#, fuzzy
-#| msgid "Tri State"
 msgid "Tri-State"
-msgstr "トライステート（Tri State）"
+msgstr "トライステート（Tri-State）"
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:179
 msgid "Passive"
-msgstr ""
+msgstr "パッシブ（Passive）"
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:181
@@ -9129,12 +8533,6 @@ msgstr "このシート番号はラベルに関連付けられる。"
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:242
-#, fuzzy
-#| msgid ""
-#| "Thus, if you place the label “TOTO” in sheet n° 3, in fact the true label "
-#| "is “TOTO_3”. If you also place a label “TOTO” in sheet n° 1 (root sheet) "
-#| "you place in fact a label called “TOTO_1”, different from “TOTO_3”. This "
-#| "is always true, even if there is only one sheet."
 msgid ""
 "Thus, if you place the label \"TOTO\" in sheet n° 3, in fact the true label "
 "is \"TOTO_3\". If you also place a label \"TOTO\" in sheet n° 1 (root sheet) "
@@ -9160,11 +8558,6 @@ msgstr "単純なラベルで言えることは、階層ラベルにも当ては
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:251
-#, fuzzy
-#| msgid ""
-#| "Thus in the same sheet, a HLabel “TOTO” is considered to be connected to "
-#| "a local label “TOTO”, but not connected to a HLabel or label called "
-#| "“TOTO” in another sheet."
 msgid ""
 "Thus in the same sheet, a HLabel \"TOTO\" is considered to be connected to a "
 "local label \"TOTO\", but not connected to a HLabel or label called \"TOTO\" "
@@ -9191,12 +8584,6 @@ msgstr "非表示電源ピン"
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:262
-#, fuzzy
-#| msgid ""
-#| "It was seen that invisible power pins were connected together if they "
-#| "have the same name. Thus all the power pins declared “Invisible Power "
-#| "Pins“ and named VCC are connected and form the equipotential VCC, "
-#| "whatever the sheet they are placed on."
 msgid ""
 "It was seen that invisible power pins were connected together if they have "
 "the same name. Thus all the power pins declared \"Invisible Power Pins\" and "
@@ -9349,23 +8736,17 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:312
-#, fuzzy
-#| msgid "Global labels"
 msgid "Look at global labels."
-msgstr "グローバルラベル"
+msgstr "グローバルラベルに注目してください。"
 
 #. type: Plain text
 #: eeschema_hierarchical_schematics.adoc:313
-#, fuzzy
-#| msgid ""
-#| "image:images/100000000000020B000001B70A60DECC."
-#| "png[100000000000020B000001B70A60DECC_png]"
 msgid ""
 "image:images/100000000000009B00000079AC689E05."
 "png[100000000000009B00000079AC689E05_png]"
 msgstr ""
-"image:images/100000000000020B000001B70A60DECC."
-"png[100000000000020B000001B70A60DECC_png]"
+"image:images/100000000000009B00000079AC689E05."
+"png[100000000000009B00000079AC689E05_png]"
 
 #. type: Title ==
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:3
@@ -11070,16 +10451,12 @@ msgstr "ダイアログウィンドウの初期化"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:795
-#, fuzzy
-#| msgid ""
-#| "One can add a new netlist plug-in user interface tab by clicking on the "
-#| "Add Plugin tab."
 msgid ""
 "One can add a new netlist plug-in user interface tab by clicking on the Add "
 "Plugin button."
 msgstr ""
 "新しいネットリストプラグインをユーザインタフェースへ追加するには、“プラグイン"
-"の追加” タブを利用します。"
+"の追加” ボタンをクリックします。"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:797
@@ -11179,16 +10556,12 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:831
-#, fuzzy
-#| msgid ""
-#| "*f:/kicad/bin/xsltproc.exe -o %O.net\n"
-#| "f:/kicad/bin/plugins/netlist_form_pads-pcb.xsl %I*\n"
 msgid ""
 "_f:/kicad/bin/xsltproc.exe -o \"%O\" f:/kicad/bin/plugins/netlist_form_pads-"
 "pcb.xsl \"%I\"_"
 msgstr ""
-"*f:/kicad/bin/xsltproc.exe -o %O.net\n"
-"f:/kicad/bin/plugins/netlist_form_pads-pcb.xsl %I*\n"
+"_f:/kicad/bin/xsltproc.exe -o \"%O\" f:/kicad/bin/plugins/netlist_form_pads-"
+"pcb.xsl \"%I\"_"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:833
@@ -11197,16 +10570,12 @@ msgstr "Linux環境の場合のコマンドを以下に示します。"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:836
-#, fuzzy
-#| msgid ""
-#| "_xsltproc -o “%O” /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl "
-#| "“%I”_"
 msgid ""
 "_xsltproc -o \"%O\" /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl "
 "\"%I\"_"
 msgstr ""
-"_xsltproc -o “%O” /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl "
-"“%I”_"
+"_xsltproc -o \"%O\" /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl "
+"\"%I\"_"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:840
@@ -11287,16 +10656,13 @@ msgstr "_under Windows._"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:866
-#, fuzzy, no-wrap
-#| msgid ""
-#| "*f:/kicad/bin/xsltproc.exe -o %O.net\n"
-#| "f:/kicad/bin/plugins/netlist_form_pads-pcb.xsl %I*\n"
+#, no-wrap
 msgid ""
 "*f:/kicad/bin/xsltproc.exe -o \"%O\"\n"
 "f:/kicad/bin/plugins/netlist_form_pads-pcb.xsl \"%I\"*\n"
 msgstr ""
-"*f:/kicad/bin/xsltproc.exe -o %O.net\n"
-"f:/kicad/bin/plugins/netlist_form_pads-pcb.xsl %I*\n"
+"*f:/kicad/bin/xsltproc.exe -o \"%O\"\n"
+"f:/kicad/bin/plugins/netlist_form_pads-pcb.xsl \"%I\"*\n"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:868
@@ -11306,16 +10672,13 @@ msgstr "under Linux:"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:871
-#, fuzzy, no-wrap
-#| msgid ""
-#| "*xsltproc -o “%O” /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl\n"
-#| "“%I”*\n"
+#, no-wrap
 msgid ""
 "*xsltproc -o \"%O\" /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl\n"
 "\"%I\"*\n"
 msgstr ""
-"*xsltproc -o “%O” /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl\n"
-"“%I”*\n"
+"*xsltproc -o \"%O\" /usr/local/kicad/bin/plugins/netlist_form_pads-pcb.xsl\n"
+"\"%I\"*\n"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:874
@@ -11384,17 +10747,19 @@ msgstr "Wiindows環境の場合:"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:901
-#, fuzzy, no-wrap
-#| msgid "*python *.exe f:/kicad/python/my_python_script.py “%I” “%O”*\n"
+#, no-wrap
 msgid "*python *.exe f:/kicad/python/my_python_script.py \"%I\" \"%O\"*\n"
-msgstr "*python *.exe f:/kicad/python/my_python_script.py “%I” “%O”*\n"
+msgstr ""
+"*python *.exe f:/kicad/python/my_python_script.py \"%I\" \"%O\"*\n"
+"\n"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:905
-#, fuzzy, no-wrap
-#| msgid "*python /usr/local/kicad/python/my_python_script.py “%I” “%O”*\n"
+#, no-wrap
 msgid "*python /usr/local/kicad/python/my_python_script.py \"%I\" \"%O\"*\n"
-msgstr "*python /usr/local/kicad/python/my_python_script.py “%I” “%O”*\n"
+msgstr ""
+"*python /usr/local/kicad/python/my_python_script.py \"%I\" \"%O\"*\n"
+"\n"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:907
@@ -11946,10 +11311,6 @@ msgstr "ネット・セクション"
 
 #. type: Plain text
 #: eeschema_creating_customized_netlists_and_bom_files.adoc:1157
-#, fuzzy
-#| msgid ""
-#| "The nets section has the delimiter <nets>. This section contains the "
-#| "“connectivity” of the schematic."
 msgid ""
 "The nets section has the delimiter <nets>. This section contains the "
 "\"connectivity\" of the schematic."
@@ -12498,12 +11859,6 @@ msgstr "ライブラリブラウザ (Viewlib)"
 
 #. type: Plain text
 #: eeschema_viewlib.adoc:12
-#, fuzzy
-#| msgid ""
-#| "Viewlib allows you to quickly examine the content of libraries. Viewlib "
-#| "is called by the tool image:images/icons/library_browse.png[icons/"
-#| "library_browse_png] or by the “place component” tool available from the "
-#| "right-hand side toolbar."
 msgid ""
 "Viewlib allows you to quickly examine the content of libraries. Viewlib is "
 "called by the tool image:images/icons/library_browse.png[icons/"


### PR DESCRIPTION
Eeschema ja.po - Follow up on 20151021.
c/w kicad-i18n kicad.po
(Due to the unification of "ERC" naming.)
