### PR TITLE
Transrated idf_exporter: Sample outlines

### DIFF
--- a/src/idf_exporter/po/ja.po
+++ b/src/idf_exporter/po/ja.po
@@ -698,7 +698,7 @@ msgstr "idfcyl と idfrect ツールで生成されたアウトラインのサ�
 #: idf_exporter.adoc:299
 #, no-wrap
 msgid "Sample outlines"
-msgstr "Sample outlines"
+msgstr "アウトラインのサンプル"
 
 #. type: Target for macro image
 #: idf_exporter.adoc:299


### PR DESCRIPTION
意図的に Sample outlines を残して有ったのかも知れませんが、ここだけ翻訳されていなかったので翻訳しました。
