### PR TITLE
kicad/po/ja.po を翻訳

### DIFF
--- a/src/kicad/po/addendum.ja
+++ b/src/kicad/po/addendum.ja
@@ -3,6 +3,7 @@ PO4A-HEADER: mode=after; position=^\[\[contributors\]\]; beginboundary=\[\[
 *翻訳*
 
 //Translators put your names below here in the addendum file
+Asuki Kono <asukiaaa AT gmail.com>, 2018.
 starfort <starfort AT nifty.com>, 2017.
 Norio Suzuki <nosuzuki AT postcard.st>, 2015.
 yoneken <yoneken AT kicad.jp>, 2011-2015.

--- a/src/kicad/po/ja.po
+++ b/src/kicad/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: KiCad-ja\n"
 "POT-Creation-Date: 2018-03-28 22:24+0900\n"
-"PO-Revision-Date: 2018-03-31 11:47+0900\n"
+"PO-Revision-Date: 2018-03-31 20:12+0900\n"
 "Last-Translator: asukiaaa <asukiaaa@gmail.com>\n"
 "Language-Team: kicad.jp <kicad@kicad.jp>\n"
 "Language: ja\n"
@@ -409,8 +409,8 @@ msgid ""
 "Hardware accelerated renderer in Pcbnew and Gerbview requires video card "
 "with support of OpenGL v2.1 or higher."
 msgstr ""
-"Pcbnew と Gerbview はハードウェアを利用して描画を高速化しているため、 OpenGL "
-"v2.1 以上をサポートするビデオカードが必要です。"
+"Pcbnew と Gerbview はハードウェアで加速されたレンダラを利用しているため、 "
+"OpenGL v2.1 以上をサポートするビデオカードが必要です。"
 
 #. type: Title ===
 #: kicad.adoc:163
@@ -428,7 +428,9 @@ msgid ""
 msgstr ""
 "kicad/template にある *kicad.pro* がデフォルト設定ファイルです。 このファイル"
 "は新規プロジェクトのテンプレートとして提供され、Eeschemaがロードするライブラ"
-"リ・ファイルのリストを設定するために使用されます。"
+"リ・ファイルのリストを設定するために使用されます。 Pcbnew に関する他のパラ"
+"メータ（デフォルトのテキストサイズ、デフォルトの伝送線路の太さ、など）もここ"
+"に保持されます。"
 
 #. type: Plain text
 #: kicad.adoc:174
@@ -959,7 +961,7 @@ msgid ""
 "Double-clicking on the schematic file runs the schematic editor, in this "
 "case opening the file *pic_programmer.sch*."
 msgstr ""
-"Eeschema アイコンをダブル・クリックすると回路図エディタが起動し、この例では "
+"回路図ファイルをダブル・クリックすると回路図エディタが起動し、この例では "
 "*pic_programmer.sch* というファイルを開きます。"
 
 #. type: Plain text
@@ -968,8 +970,8 @@ msgid ""
 "Double-clicking on the board file runs the layout editor, in this case "
 "opening the file *pic_programmer.kicad_pcb*."
 msgstr ""
-"Pcbnew アイコンをダブル・クリックするとプリント基板エディタが起動し、この例で"
-"は *pic_programmer.kicad_pcb* というファイルを開きます。"
+"基板ファイルをダブル・クリックするとプリント基板エディタが起動し、この例では "
+"*pic_programmer.kicad_pcb* というファイルを開きます。"
 
 #. type: Plain text
 #: kicad.adoc:375

--- a/src/kicad/po/ja.po
+++ b/src/kicad/po/ja.po
@@ -7,14 +7,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: KiCad-ja\n"
 "POT-Creation-Date: 2018-03-28 22:24+0900\n"
-"PO-Revision-Date: 2017-03-20 15:25+0900\n"
-"Last-Translator: starfort_jp <starfort@nifty.com>\n"
+"PO-Revision-Date: 2018-03-31 11:47+0900\n"
+"Last-Translator: asukiaaa <asukiaaa@gmail.com>\n"
 "Language-Team: kicad.jp <kicad@kicad.jp>\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 1.8.12\n"
+"X-Generator: Poedit 2.0.6\n"
 
 #. type: Title ===
 #: kicad.adoc:6 kicad.adoc:44
@@ -35,13 +35,6 @@ msgstr "*著作権*\n"
 
 #. type: Plain text
 #: kicad.adoc:18
-#, fuzzy
-#| msgid ""
-#| "This document is Copyright (C) 2010-2015 by its contributors as listed "
-#| "below. You may distribute it and/or modify it under the terms of either "
-#| "the GNU General Public License (http://www.gnu.org/licenses/gpl.html), "
-#| "version 3 or later, or the Creative Commons Attribution License (http://"
-#| "creativecommons.org/licenses/by/3.0/), version 3.0 or later."
 msgid ""
 "This document is Copyright (C) 2010-2018 by its contributors as listed "
 "below. You may distribute it and/or modify it under the terms of either the "
@@ -49,7 +42,7 @@ msgid ""
 "or later, or the Creative Commons Attribution License (http://"
 "creativecommons.org/licenses/by/3.0/), version 3.0 or later."
 msgstr ""
-"このドキュメントは以下の貢献者により著作権所有 (C) 2010-2015 されています。あ"
+"このドキュメントは以下の貢献者により著作権所有 (C) 2010-2018 されています。あ"
 "なたは、GNU General Public License ( http://www.gnu.org/licenses/gpl.html ) "
 "のバージョン 3 以降、あるいはクリエイティブ・コモンズ・ライセンス ( http://"
 "creativecommons.org/licenses/by/3.0/ ) のバージョン 3.0 以降のいずれかの条件"
@@ -95,13 +88,9 @@ msgstr "KiCad ソフトウェアについて : https://bugs.launchpad.net/kicad"
 
 #. type: Plain text
 #: kicad.adoc:36
-#, fuzzy
-#| msgid ""
-#| "About KiCad software i18n: https://github.com/KiCad/kicad-i18n/issues"
 msgid "About KiCad translation: https://github.com/KiCad/kicad-i18n/issues"
 msgstr ""
-"KiCad ソフトウェアの国際化について : https://github.com/KiCad/kicad-i18n/"
-"issues"
+"KiCad ソフトウェアの翻訳について : https://github.com/KiCad/kicad-i18n/issues"
 
 #. type: Plain text
 #: kicad.adoc:39
@@ -274,13 +263,7 @@ msgstr "*回路図エディタ:*\n"
 
 #. type: delimited block |
 #: kicad.adoc:103
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|*.sch |Schematic files, which do not contain the components themselves.\n"
-#| "|*.lib |Schematic component library files, containing the component descriptions: graphic shape, pins, fields.\n"
-#| "|*.dcm |Schematic component library documentation, containing some component descriptions:\n"
-#| "comments, keywords, reference to data sheets.\n"
-#| "|*_cache.lib |Schematic component library cache file, containing a copy of the components used in the schematic project.\n"
+#, no-wrap
 msgid ""
 "|*.sch |Schematic files, which do not contain the components themselves.\n"
 "|*.lib |Schematic component library files, containing the component descriptions: graphic shape, pins, fields.\n"
@@ -295,6 +278,8 @@ msgstr ""
 "|*.dcm |コンポーネントライブラリの説明ドキュメント。\n"
 "各コンポーネントに対するコメント、キーワード、データシートへの参照。\n"
 "|*_cache.lib |コンポーネントライブラリのキャッシュファイル。回路図で使用しているコンポーネントのコピーを保存する。\n"
+"|sym-lib-table |シンボル・ライブラリのリスト。(_シンボル・ライブラリ・テーブル_):\n"
+"回路図エディタで読み込まれるシンボル・ライブラリのリスト。\n"
 
 #. type: Plain text
 #: kicad.adoc:106
@@ -304,18 +289,7 @@ msgstr "*基板エディタのファイルとフォルダ:*\n"
 
 #. type: delimited block |
 #: kicad.adoc:118
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|*.kicad_pcb |Board file containing all info but the page layout.\n"
-#| "|*.pretty |Footprint library folders. The folder itself is the library.\n"
-#| "|*.kicad_mod |Footprint files, containing one footprint description each.\n"
-#| "|*.brd |Board file in the legacy format.\n"
-#| "Can be read, but not written, by the current board editor.\n"
-#| "|*.mod |Footprint library in the legacy format.\n"
-#| "Can be read by the footprint or the board editor, but not written.\n"
-#| "|fp-lib-table |Footprint library list (_footprint libraries table_):\n"
-#| "list of footprint libraries (various formats) which are loaded\n"
-#| "by the board or the footprint editor or CvPcb.\n"
+#, no-wrap
 msgid ""
 "|*.kicad_pcb |Board file containing all info but the page layout.\n"
 "|*.pretty |Footprint library folders. The folder itself is the library.\n"
@@ -369,13 +343,7 @@ msgstr "*スペシャルファイル:*\n"
 
 #. type: delimited block |
 #: kicad.adoc:138
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|*.cmp |Association between components used in the schematic and their footprints.\n"
-#| "It can be created by Pcbnew, and imported by Eeschema.\n"
-#| "The purpose is a back import from Pcbnew to Eeschema, for users\n"
-#| "who change footprints inside Pcbnew (for instance using _Exchange Footprints_ command)\n"
-#| "and want to import these changes in schematic.\n"
+#, no-wrap
 msgid ""
 "|*.cmp |Association between components used in the schematic and their footprints.\n"
 "It can be created by Pcbnew and imported by Eeschema.\n"
@@ -387,9 +355,6 @@ msgstr ""
 "Pcbnew がこのファイルを作成し、Eeschema が取り込みます。\n"
 "例えば Pcbnew 上で _フットプリントを変更_ コマンドでフットプリントを変更した\n"
 "とします。この変更を回路図に反映するため Eeschema で読み込みます。\n"
-"\n"
-"\n"
-"\n"
 
 #. type: Plain text
 #: kicad.adoc:141
@@ -444,6 +409,8 @@ msgid ""
 "Hardware accelerated renderer in Pcbnew and Gerbview requires video card "
 "with support of OpenGL v2.1 or higher."
 msgstr ""
+"Pcbnew と Gerbview はハードウェアを利用して描画を高速化しているため、 OpenGL "
+"v2.1 以上をサポートするビデオカードが必要です。"
 
 #. type: Title ===
 #: kicad.adoc:163
@@ -453,13 +420,6 @@ msgstr "デフォルト設定の初期化"
 
 #. type: Plain text
 #: kicad.adoc:170
-#, fuzzy
-#| msgid ""
-#| "A default configuration file named *kicad.pro* is supplied in kicad/"
-#| "template. It serves as a template for any new project and is used to set "
-#| "the list of library files loaded by Eeschema.  A few other parameters for "
-#| "Pcbnew (default text size, default line thickness, etc.) are also stored "
-#| "here."
 msgid ""
 "The default configuration file named *kicad.pro* is supplied in kicad/"
 "template. It serves as a template for any new project and is used to set the "
@@ -504,29 +464,16 @@ msgstr "KiCadを起動して *kicad.pro* プロジェクトを読み込みます
 
 #. type: Plain text
 #: kicad.adoc:187
-#, fuzzy
-#| msgid ""
-#| "Run Eeschema via KiCad.  Modify and update the Eeschema configuration, to "
-#| "set the list of libraries you want to use each time you create new "
-#| "projects."
 msgid ""
 "Run Eeschema via KiCad manager.  Modify and update the Eeschema "
 "configuration, to set the list of libraries you want to use each time you "
 "create new projects."
 msgstr ""
-"KiCad から Eeschema を起動します。新しいプロジェクトを作るときに使いたいライ"
-"ブラリのリストを設定するため Eeschema の設定を変更します。"
+"KiCad マネージャから Eeschema を起動します。新しいプロジェクトを作るときに使"
+"いたいライブラリのリストを設定するため Eeschema の設定を変更します。"
 
 #. type: Plain text
 #: kicad.adoc:194
-#, fuzzy
-#| msgid ""
-#| "Run Pcbnew via KiCad.  Modify and update the Pcbnew configuration, "
-#| "especially the footprint library list.  Pcbnew will create or update a "
-#| "library list file called **footprint library table**.  There are 2 "
-#| "library list files (named fp-lib-table): The first (located in the user "
-#| "home directory) is global for all projects and the second (located in the "
-#| "project directory), if it exists, is specific to the project."
 msgid ""
 "Run Pcbnew via KiCad manager.  Modify and update the Pcbnew configuration, "
 "especially the footprint library list.  Pcbnew will create or update a "
@@ -535,19 +482,19 @@ msgid ""
 "directory) is global for all projects and the second (located in the project "
 "directory) is optional and specific to the project."
 msgstr ""
-"KiCad から Pcbnew を起動します。フットプリント・ライブラリ・リストなど "
-"Pcbnew の設定を変更します。Pcbnew は、 **フットプリント・ライブラリ・テーブル"
-"** というライブラリ・リスト・ファイルを作成または更新します。 二箇所に (fp-"
-"lib-table という名前の) ライブラリ・ファイルがあります: ホームディレクトリに"
-"ある fp-lib-table ファイルは、すべてのプロジェクトで使用されます。そしてプロ"
-"ジェクトのディレクトリにもある場合は、そのプロジェクト専用で使われます。"
+"KiCad マネージャから Pcbnew を起動します。フットプリント・ライブラリ・リスト"
+"など Pcbnew の設定を変更します。Pcbnew は、 **フットプリント・ライブラリ・"
+"テーブル** というライブラリ・リスト・ファイルを作成または更新します。 二箇所"
+"に (fp-lib-table という名前の) ライブラリ・ファイルがあります: ホームディレク"
+"トリにある fp-lib-table ファイルは、すべてのプロジェクトで使用されます。そし"
+"てプロジェクトのディレクトリにもある場合は、そのプロジェクト専用で使われま"
+"す。"
 
 #. type: Title ===
 #: kicad.adoc:195
-#, fuzzy, no-wrap
-#| msgid "Installation and configuration"
+#, no-wrap
 msgid "Paths configuration"
-msgstr "インストールと設定"
+msgstr "パスの設定"
 
 #. type: Plain text
 #: kicad.adoc:200
@@ -562,20 +509,16 @@ msgstr ""
 
 #. type: Plain text
 #: kicad.adoc:205
-#, fuzzy
-#| msgid ""
-#| "This is useful when absolute paths are not known or are subject to "
-#| "change, and also when one base path is shared by many similar items.  "
-#| "Consider the following which may be installed in varying locations:"
 msgid ""
 "This is useful when absolute paths are not known or are subject to change (e."
 "g.  when you transfer a project to a different computer), and also when one "
 "base path is shared by many similar items. Consider the following which may "
 "be installed in varying locations:"
 msgstr ""
-"これは、絶対パスを事前に決められなかったり、変更の可能性がある場合、また一つ"
-"のベース・パスを多くの同様なアイテムで共有するような場合に役立ちます。いろい"
-"ろな場所へインストールされる以下のものについて考慮してください:"
+"これは、（プロジェクトを別のコンピュータに送るときなど）絶対パスを事前に決め"
+"られなかったり変更の可能性がある場合、また一つのベース・パスを多くの同様なア"
+"イテムで共有するような場合に役立ちます。いろいろな場所へインストールされる以"
+"下のものについて考慮してください:"
 
 #. type: Plain text
 #: kicad.adoc:207
@@ -594,11 +537,6 @@ msgstr "フットプリントの定義で使用される 3D シェイプ・フ�
 
 #. type: Plain text
 #: kicad.adoc:213
-#, fuzzy
-#| msgid ""
-#| "For instance, the path to the *_connect.pretty_* footprint library, when "
-#| "using the *KISYSMOD* environment variable, would be *_$\\{KISYSMOD\\}/"
-#| "connect.pretty_*"
 msgid ""
 "For instance, the path to the *_connect.pretty_* footprint library, when "
 "using the *KISYSMOD* environment variable, would be defined as *_$\\{KISYSMOD"
@@ -610,10 +548,6 @@ msgstr ""
 
 #. type: Plain text
 #: kicad.adoc:216
-#, fuzzy
-#| msgid ""
-#| "This option allows you to define a path with an environment variable, and "
-#| "add your own environment variables to define personal paths, if needed."
 msgid ""
 "This option allows you to define a path using an environment variable, and "
 "add your own environment variables to define personal paths, if needed."
@@ -629,16 +563,7 @@ msgstr "*KiCad 環境変数:*\n"
 
 #. type: delimited block |
 #: kicad.adoc:229
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|KICAD_PTEMPLATES |Templates used during project creation.\n"
-#| "If you are using this variable, it must be defined.\n"
-#| "|KIGITHUB |Frequently used in example footprint lib tables.\n"
-#| "If you are using this variable, it must be defined.\n"
-#| "|KISYS3DMOD |Base path of 3D shapes files,\n"
-#| "and must be defined because an absolute path is not usually used.\n"
-#| "|KISYSMOD |Base path of footprint library folders,\n"
-#| "and must be defined if an absolute path is not used in footprint library names.\n"
+#, no-wrap
 msgid ""
 "|KICAD_PTEMPLATES |Templates used during project creation.\n"
 "If you are using this variable, it must be defined.\n"
@@ -652,6 +577,7 @@ msgid ""
 msgstr ""
 "|KICAD_PTEMPLATES |プロジェクトの作成で使用されるテンプレート。\n"
 "この変数を使用する場合には、ユーザーによる定義が必要です。\n"
+"|KICAD_SYMBOL_DIR |シンボル・ライブラリのベース・パス。\n"
 "|KIGITHUB |フットプリント・ライブラリ・テーブルでよく使用されます。\n"
 "この変数を使用する場合には、ユーザーによる定義が必要です。\n"
 "|KISYS3DMOD |3D シェイプ・ファイルのベース・パス。\n"
@@ -707,6 +633,8 @@ msgid ""
 "You may define your favorite text editor and PDF viewer. These settings are "
 "used whenever you want to open a text or PDF file."
 msgstr ""
+"お気に入りのテキスト・エディタや PDF ビューアを定義できます。これらの設定は、"
+"テキストや PDF ファイルを開く際に利用されます。"
 
 #. type: Plain text
 #: kicad.adoc:248
@@ -778,19 +706,12 @@ msgstr ""
 
 #. type: Title ===
 #: kicad.adoc:269
-#, fuzzy, no-wrap
-#| msgid "Creating templates"
+#, no-wrap
 msgid "Creating a new project"
-msgstr "テンプレートの作成"
+msgstr "新規プロジェクトの作成"
 
 #. type: Plain text
 #: kicad.adoc:275
-#, fuzzy
-#| msgid ""
-#| "In order to manage a KiCad project of schematic files, printed circuit "
-#| "board files, supplementary libraries, manufacturing files for photo-"
-#| "tracing, drilling and automatic component placement files, it is "
-#| "recommended to create a project as follows:"
 msgid ""
 "In order to manage a KiCad project consisting of schematic files, printed "
 "circuit board files, supplementary libraries, manufacturing files for photo-"
@@ -870,7 +791,7 @@ msgstr ""
 #: kicad.adoc:304
 #, no-wrap
 msgid "Importing a foreign project"
-msgstr ""
+msgstr "プロジェクトのインポート"
 
 #. type: Plain text
 #: kicad.adoc:308
@@ -878,6 +799,9 @@ msgid ""
 "KiCad is able to import files created using other software packages. "
 "Currently only Eagle 6.x or newer (XML format) is supported."
 msgstr ""
+"他のソフトウェアで作られたファイルを KiCad にインポートできます。いまのとこ"
+"ろ、 Eagle 6.x 以上で作られた XML フォーマットのファイルのみに対応していま"
+"す。"
 
 #. type: Plain text
 #: kicad.adoc:312
@@ -889,21 +813,20 @@ msgid ""
 "directory to store the imported files, which are going to be saved as a "
 "KiCad project."
 msgstr ""
+"プロジェクトをインポートするために、インポートのためのファイル選択ダイアログ"
+"から回路図か基板のファイルのどちらかを選択します。インポートする回路図と基板"
+"のファイルは同じベース名（例: project.sch と project.brd）である必要がありま"
+"す。ファイルを選択したら、インポート後に KiCad プロジェクトとして扱われるファ"
+"イルの保存先ディレクトリを選択します。"
 
 #. type: Title ==
 #: kicad.adoc:313
-#, fuzzy, no-wrap
-#| msgid "Using KiCad manager"
+#, no-wrap
 msgid "Using KiCad project manager"
 msgstr "KiCad マネージャーの使用方法"
 
 #. type: Plain text
 #: kicad.adoc:317
-#, fuzzy
-#| msgid ""
-#| "The KiCad Manager (kicad or kicad.exe) is a tool which can easily run the "
-#| "other tools (schematic and PCB editors, Gerber viewer and utility tools) "
-#| "when creating a design."
 msgid ""
 "KiCad project manager (kicad or kicad.exe) is a tool which can easily run "
 "the other tools (schematic and PCB editors, Gerber viewer and utility tools) "
@@ -941,10 +864,9 @@ msgstr ""
 
 #. type: Title ===
 #: kicad.adoc:328
-#, fuzzy, no-wrap
-#| msgid "*Project manager file:*\n"
+#, no-wrap
 msgid "Project manager window"
-msgstr "*プロジェクト・マネージャ・ファイル:*\n"
+msgstr "*プロジェクト・マネージャ・ウィンドウ:*"
 
 #. type: Target for macro image
 #: kicad.adoc:330
@@ -973,9 +895,6 @@ msgstr "ユーティリティ起動ペイン"
 
 #. type: Plain text
 #: kicad.adoc:341
-#, fuzzy
-#| msgid ""
-#| "KiCad allows you to run all stand alone software tools that come with it."
 msgid ""
 "KiCad allows you to run all standalone software tools that come with it."
 msgstr ""
@@ -1036,10 +955,6 @@ msgstr "images/project_tree.png"
 
 #. type: Plain text
 #: kicad.adoc:369
-#, fuzzy
-#| msgid ""
-#| "Double-clicking on the Eeschema icon runs the schematic editor, in this "
-#| "case opening the file *pic_programmer.sch*."
 msgid ""
 "Double-clicking on the schematic file runs the schematic editor, in this "
 "case opening the file *pic_programmer.sch*."
@@ -1049,10 +964,6 @@ msgstr ""
 
 #. type: Plain text
 #: kicad.adoc:372
-#, fuzzy
-#| msgid ""
-#| "Double-clicking on the Pcbnew icon runs the layout editor, in this case "
-#| "opening the file *pic_programmer.kicad_pcb*."
 msgid ""
 "Double-clicking on the board file runs the layout editor, in this case "
 "opening the file *pic_programmer.kicad_pcb*."
@@ -1088,22 +999,7 @@ msgstr "KiCad のトップ・ツールバーからは、次の基本的なファ
 
 #. type: delimited block |
 #: kicad.adoc:399
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/new_project.png[]\n"
-#| "|Create a project file. If the template *kicad.pro* is found in\n"
-#| "*kicad/template*, it is copied into the working directory.\n"
-#| "|image:images/icons/new_project_with_template.png[]\n"
-#| "|Create a project from a template.\n"
-#| "|image:images/icons/open_project.png[]\n"
-#| "|Open an existing project.\n"
-#| "|image:images/icons/save_project.png[]\n"
-#| "|Update and save the current project tree.\n"
-#| "|image:images/icons/zip.png[]\n"
-#| "|Create a zip archive of the whole project. This includes schematic\n"
-#| "files, libraries, PCB, etc.\n"
-#| "|image:images/icons/reload.png[]\n"
-#| "|Rebuild and redraw the tree view, sometimes needed after a tree change.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/new_project.png[]\n"
 "|Create a new project. If the default template file (kicad.pro) is found in\n"
@@ -1121,7 +1017,7 @@ msgid ""
 "|Refresh the tree view, sometimes needed after a tree change.\n"
 msgstr ""
 "|image:images/icons/new_project.png[]\n"
-"|プロジェクトファイルの作成。*kicad/template* にテンプレート\n"
+"|新規プロジェクトファイルの作成。*kicad/template* にテンプレート\n"
 " *kicad.pro* がある場合は、作業ディレクトリにコピーされます。\n"
 "|image:images/icons/new_project_with_template.png[]\n"
 "|テンプレートからプロジェクトを作成。\n"
@@ -1143,13 +1039,6 @@ msgstr "プロジェクト・テンプレート"
 
 #. type: Plain text
 #: kicad.adoc:407
-#, fuzzy
-#| msgid ""
-#| "A template facilitates the easy creation of a new project, based on a "
-#| "template definition. Templates may contain pre-defined board outlines, "
-#| "connector positions, schematic elements, design rules, etc. Complete "
-#| "schematics and/or PCBs used as seed files for the new project may even be "
-#| "included."
 msgid ""
 "Using a project template facilitates setting up a new project with "
 "predefined settings. Templates may contain pre-defined board outlines, "
@@ -1157,7 +1046,7 @@ msgid ""
 "schematics and/or PCBs used as seed files for the new project may even be "
 "included."
 msgstr ""
-"テンプレートを使うとテンプレート定義に基づいた新規プロジェクトを容易に作成で"
+"テンプレートを使うことで、あらかじめ設定が定義された新規プロジェクトを作成で"
 "きます。テンプレートは、事前に定義された基板外形、コネクタ位置、回路要素、設"
 "計ルールなどを含んでいます。新規プロジェクト用ファイルの派生元として使われる"
 "完全な回路図や基板を含めることも可能です。"
@@ -1185,22 +1074,16 @@ msgstr "images/ja/template_selector.png"
 
 #. type: Plain text
 #: kicad.adoc:419
-#, fuzzy
-#| msgid ""
-#| "A single click on a template's icon will load that template's "
-#| "information, and a further click on the OK button creates the new "
-#| "project. The template files will be copied to the new project location "
-#| "and renamed to reflect the new project's name."
 msgid ""
 "A single click on a template's icon will display the template information, "
 "and a further click on the OK button creates the new project. The template "
 "files will be copied to the new project location and renamed to reflect the "
 "new project's name."
 msgstr ""
-"テンプレート・アイコンのシングル・クリックでテンプレートの情報が読み込まれ、"
-"更に OK ボタンをクリックすると新しいプロジェクトが作成されます。テンプレー"
-"ト・ファイルは新規プロジェクトの場所へコピーされ、新しいプロジェクトの名前を"
-"反映したものへとリネームされます。"
+"テンプレート・アイコンのシングル・クリックでテンプレートの情報が表示され、更"
+"に OK ボタンをクリックすると新しいプロジェクトが作成されます。テンプレート・"
+"ファイルは新規プロジェクトの場所へコピーされ、新しいプロジェクトの名前を反映"
+"したものへとリネームされます。"
 
 #. type: Plain text
 #: kicad.adoc:421
@@ -1222,7 +1105,7 @@ msgstr "テンプレートが置かれる場所:"
 #. type: Plain text
 #: kicad.adoc:427
 msgid "KiCad looks for template files in the following paths:"
-msgstr ""
+msgstr "KiCad はこれらパスのテンプレートを読み込みます:"
 
 #. type: Plain text
 #: kicad.adoc:430
@@ -1289,11 +1172,6 @@ msgstr "テンプレートの作成"
 
 #. type: Plain text
 #: kicad.adoc:451
-#, fuzzy
-#| msgid ""
-#| "The template name is the directory name under which the template files "
-#| "are stored. The metadata directory, in a subdirectory named *meta*, "
-#| "contains files which describe the template."
 msgid ""
 "The template name is the directory name where the template files are stored. "
 "The metadata directory is a subdirectory named *meta* containing files "
@@ -1314,17 +1192,14 @@ msgstr ""
 
 #. type: Plain text
 #: kicad.adoc:458
-#, fuzzy
-#| msgid ""
-#| "All files and directories which start with the template name will be "
-#| "renamed with the new project file name, excluding the file extension."
 msgid ""
 "When a new project is created from a template, all files and directories "
 "starting with the template name will be renamed with the new project file "
 "name, excluding the file extension."
 msgstr ""
-"テンプレートの名前で始まる全てのファイルとディレクトリは、拡張子部分を除い"
-"て、新規プロジェクトのファイル名で名前を置換されます。"
+"プロジェクトがテンプレートから作成された場合、テンプレートの名前で始まる全て"
+"のファイルとディレクトリは、拡張子部分を除いて、新規プロジェクトのファイル名"
+"で名前を置換されます。"
 
 #. type: Plain text
 #: kicad.adoc:462
@@ -1340,12 +1215,11 @@ msgstr ""
 
 #. type: Plain text
 #: kicad.adoc:464
-#, fuzzy
-#| msgid "Here are project files for a *raspberrypi-gpio* template:"
 msgid ""
 "Here is an example showing project files for *raspberrypi-gpio* template:"
 msgstr ""
-"これは、 *raspberrypi-gpio* テンプレート用のプロジェクト・ファイルです:"
+"ここで例として表示するのは、 *raspberrypi-gpio* テンプレート用のプロジェク"
+"ト・ファイルです:"
 
 #. type: Target for macro image
 #: kicad.adoc:465


### PR DESCRIPTION
翻訳の流れを確認したいため `kicad/po/ja.po` の一部を翻訳しました。
このような変更で良いか、確認をお願いします。

https://github.com/kicad-jp/kicad-doc/pull/90 を `ja_5.0.0` にマージしてもらえるなら、それをベースにして翻訳を進めたいです。