### PR TITLE
Translate part of src/eeschema/po/ja.po for 5.0.0

### DIFF
--- a/src/eeschema/po/addendum.ja
+++ b/src/eeschema/po/addendum.ja
@@ -3,6 +3,7 @@ PO4A-HEADER: mode=after; position=^\[\[contributors\]\]; beginboundary=\[\[
 *翻訳*
 
 //Translators put your names below here in the addendum file
+Asuki Kono <asukiaaa At gmail.com>, 2018.
 starfort <starfort AT nifty.com>, 2015-2017.
 Norio Suzuki <nosuzuki AT postcard.st>, 2015.
 yoneken <yoneken AT kicad.jp>, 2011-2015.

--- a/src/eeschema/po/ja.po
+++ b/src/eeschema/po/ja.po
@@ -182,7 +182,7 @@ msgid ""
 "Annotate only symbols that are currently not annotated.  Symbols that are "
 "not annotated will have a designator which ends with a '?' character."
 msgstr ""
-"アノテートサれていないシンボルだけアノテート。 \"?\" で終わるリファレンス（参"
+"アノテートされていないシンボルだけアノテート。 \"?\" で終わるリファレンス（参"
 "照番号）を持つシンボルが対象です。"
 
 #. type: Plain text

--- a/src/eeschema/po/ja.po
+++ b/src/eeschema/po/ja.po
@@ -2,14 +2,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Eeschema-ja\n"
 "POT-Creation-Date: 2018-03-28 22:24+0900\n"
-"PO-Revision-Date: 2017-09-10 01:16+0900\n"
-"Last-Translator: starfort_jp <starfort@nifty.com>\n"
+"PO-Revision-Date: 2018-04-03 22:18+0900\n"
+"Last-Translator: asukiaaa <asukiaaa@gmail.com>\n"
 "Language-Team: kicad.jp <kicad@kicad.jp>\n"
 "Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"X-Generator: Poedit 2.0.3\n"
+"X-Generator: Poedit 2.0.6\n"
 
 # PR1:07102015 proofreading - chapter1
 # PR2:07122015 proofreading - chapter2,3
@@ -39,13 +39,6 @@ msgstr "*著作権*\n"
 
 #. type: Plain text
 #: eeschema.adoc:18
-#, fuzzy
-#| msgid ""
-#| "This document is Copyright (C) 2010-2015 by its contributors as listed "
-#| "below. You may distribute it and/or modify it under the terms of either "
-#| "the GNU General Public License (http://www.gnu.org/licenses/gpl.html), "
-#| "version 3 or later, or the Creative Commons Attribution License (http://"
-#| "creativecommons.org/licenses/by/3.0/), version 3.0 or later."
 msgid ""
 "This document is Copyright (C) 2010-2018 by its contributors as listed "
 "below. You may distribute it and/or modify it under the terms of either the "
@@ -53,7 +46,7 @@ msgid ""
 "or later, or the Creative Commons Attribution License (http://"
 "creativecommons.org/licenses/by/3.0/), version 3.0 or later."
 msgstr ""
-"このドキュメントは以下の貢献者により著作権所有 (C) 2010-2015 されています。あ"
+"このドキュメントは以下の貢献者により著作権所有 (C) 2010-2018 されています。あ"
 "なたは、GNU General Public License ( http://www.gnu.org/licenses/gpl.html ) "
 "のバージョン 3 以降、あるいはクリエイティブ・コモンズ・ライセンス ( http://"
 "creativecommons.org/licenses/by/3.0/ ) のバージョン 3.0 以降のいずれかの条件"
@@ -99,13 +92,9 @@ msgstr "KiCad ソフトウェアについて : https://bugs.launchpad.net/kicad"
 
 #. type: Plain text
 #: eeschema.adoc:36
-#, fuzzy
-#| msgid ""
-#| "About KiCad software i18n: https://github.com/KiCad/kicad-i18n/issues"
 msgid "About KiCad translation: https://github.com/KiCad/kicad-i18n/issues"
 msgstr ""
-"KiCad ソフトウェアの国際化について : https://github.com/KiCad/kicad-i18n/"
-"issues"
+"KiCad ソフトウェアの翻訳について : https://github.com/KiCad/kicad-i18n/issues"
 
 #. type: Plain text
 #: eeschema.adoc:40
@@ -115,17 +104,14 @@ msgstr "*発行日とソフトウエアのバージョン*\n"
 
 #. type: Plain text
 #: eeschema.adoc:42
-#, fuzzy
-#| msgid "Published on may 30, 2015."
 msgid "Published on May 30, 2015."
 msgstr "2015年5月30日 発行"
 
 #. type: Title ==
 #: eeschema_automatic_classification_annotation.adoc:3
-#, fuzzy, no-wrap
-#| msgid "Annotation tool"
+#, no-wrap
 msgid "Symbol Annotation Tool"
-msgstr "アノテーションツール"
+msgstr "シンボル アノテーション ツール"
 
 #. type: Title ===
 #: eeschema_automatic_classification_annotation.adoc:5
@@ -141,14 +127,6 @@ msgstr "はじめに"
 
 #. type: Plain text
 #: eeschema_automatic_classification_annotation.adoc:13
-#, fuzzy
-#| msgid ""
-#| "The automatic classification annotation tool allows you to automatically "
-#| "assign a designator to components in your schematic. For multi-parts "
-#| "components, assign a multi-part suffix to minimize the number of these "
-#| "packages. The automatic classification annotation tool is accessible via "
-#| "the icon image:images/icons/annotate.png[icons_annotate_png].  Here you "
-#| "find its main window."
 msgid ""
 "The annotation tool allows you to automatically assign a designator to "
 "symbols in your schematic. Annotation of symbols with multiple units will "
@@ -156,12 +134,12 @@ msgid ""
 "annotation tool is accessible via the icon image:images/icons/annotate."
 "png[icons_annotate_png].  Here you find its main window."
 msgstr ""
-"“回路図のアノテーション” ツールを用いることで、回路図中のコンポーネントに自動"
-"的にリファレンス（参照番号）を割り当てることができます。複数ユニットを持つコ"
-"ンポーネントについては，使用パッケージ数が最小となるように部品番号を割り当て"
-"ます。アノテーションツールは、アイコン  image:images/icons/annotate."
-"png[icons_annotate_png] をクリックすることで利用できます。以下に “回路図のア"
-"ノテーション” のメインウィンドウを示します。"
+"アノテーションツールを使うことで、回路図中のシンボルに自動的にリファレンス"
+"（参照番号）を割り当てることができます。複数ユニットを持つシンボルについて"
+"は，使用パッケージ数が最小となるように部品番号を割り当てます。アノテーション"
+"ツールは、アイコン  image:images/icons/annotate.png[icons_annotate_png] をク"
+"リックすることで利用できます。以下に “回路図をアノテーション” のメインウィン"
+"ドウを示します。"
 
 #. type: Named 'alt' AttributeList argument for macro 'image'
 #: eeschema_automatic_classification_annotation.adoc:14
@@ -180,30 +158,23 @@ msgstr "images/ja/annotate-dialog.png"
 #. type: Plain text
 #: eeschema_automatic_classification_annotation.adoc:17
 msgid "Available annotation schemes:"
-msgstr ""
+msgstr "アノテーション方法一覧 :"
 
 #. type: Plain text
 #: eeschema_automatic_classification_annotation.adoc:19
-#, fuzzy
-#| msgid "Annotate all the components (reset existing annotation option)"
 msgid "Annotate all the symbols (reset existing annotation option)"
 msgstr ""
-"全てのコンポーネントをアノテート （「既存のアノテーションをリセット（Ｒ）」を"
-"選択）"
+"全てのシンボルをアノテート（「既存のアノテーションをリセット (R) 」を選択）。"
 
 #. type: Plain text
 #: eeschema_automatic_classification_annotation.adoc:21
-#, fuzzy
-#| msgid ""
-#| "Annotate all the components, but do not swap any previously annotated "
-#| "multi-unit parts."
 msgid ""
 "Annotate all the symbols, but do not swap any previously annotated multi-"
 "unit parts."
 msgstr ""
-"既存の複数ユニットを持つコンポーネント内の順番を入れ替えないで、全てのコン"
-"ポーネントをアノテート。（「既存のアノテーションをリセット、ただし複数ユニッ"
-"トを持つ部品はキープ（Ｅ）」を選択）。"
+"既存の複数ユニットをシンボルの順番を入れ替えないで、全てのシンボルをアノテー"
+"ト（「既存のアノテーションをリセット、ただし複数ユニットを持つ部品はキープ"
+"（Ｅ）」を選択）。"
 
 #. type: Plain text
 #: eeschema_automatic_classification_annotation.adoc:23
@@ -211,29 +182,22 @@ msgid ""
 "Annotate only symbols that are currently not annotated.  Symbols that are "
 "not annotated will have a designator which ends with a '?' character."
 msgstr ""
+"アノテートサれていないシンボルだけアノテート。 \"?\" で終わるリファレンス（参"
+"照番号）を持つシンボルが対象です。"
 
 #. type: Plain text
 #: eeschema_automatic_classification_annotation.adoc:24
 msgid "Annotate the whole hierarchy (use the entire schematic option)."
-msgstr "全階層をアノテート （「全ての回路図，階層を使用（Ｅ）」を選択）。"
+msgstr "全階層をアノテート （「全ての回路図，階層を使用 (E) 」を選択）。"
 
 #. type: Plain text
 #: eeschema_automatic_classification_annotation.adoc:25
 msgid "Annotate the current sheet only (use current page only option)."
 msgstr ""
-"現在のシートのみをアノテート （「現在のページのみ使用（Ｐ）」を選択）。"
+"現在のシートのみをアノテート （「現在のページのみ使用 (Ｐ) 」を選択）。"
 
 #. type: Plain text
 #: eeschema_automatic_classification_annotation.adoc:31
-#, fuzzy
-#| msgid ""
-#| "The ``Reset, but do not swap any annotated multi-unit parts'' option "
-#| "keeps all existing associations between multi-unit parts. That is, if you "
-#| "have U2A and U2B, they may be reannotated to U1A and U1B respectively, "
-#| "but they will never be reannotated to U1A and U2A, nor to U2B and U2A. "
-#| "This is useful if you want to ensure that pin groupings are maintained, "
-#| "if you have already decided by yourself which subunits are best placed "
-#| "where."
 msgid ""
 "The ``Reset, but do not swap any annotated multi-unit parts'' option keeps "
 "all existing associations between symbols with multilple units. For example, "
@@ -242,11 +206,11 @@ msgid ""
 "you want to ensure that pin groupings are maintained."
 msgstr ""
 "''既存のアノテーションをリセット、ただし複数ユニットを持つ部品はキープ''オプ"
-"ションは、複数ユニットを持つコンポーネント内の全ての関連性を保存します。これ"
-"は、もし U2A と U2B があったなら、それぞれ U1A と U1B へと番号が振られること"
-"はあっても、 U1A と U2A、または U2B と U2A とはならないということです。これ"
-"は、ピングループを確実に維持したい時、配置するのに都合がいいように定義した子"
-"部品がある時、に役立ちます。"
+"ションは、複数ユニットを持つシンボルの全ての関連性を保存します。これは、もし "
+"U2A と U2B があったなら、それぞれ U1A と U1B へと番号が振られることはあって"
+"も、 U1A と U2A、または U2B と U2A とはならないということです。これは、ピング"
+"ループを確実に維持したい時、配置するのに都合がいいように定義した子部品がある"
+"時、に役立ちます。"
 
 #. type: Plain text
 #: eeschema_automatic_classification_annotation.adoc:34
@@ -270,9 +234,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_automatic_classification_annotation.adoc:40
-#, fuzzy
-#| msgid ""
-#| "The Annotation Choice gives the method used to calculate reference Id:"
 msgid "The Annotation Choice gives the method used to calculate reference:"
 msgstr ""
 "「アノテーションの選択」オプションでは、リファレンス（参照番号）の計算方法を"
@@ -280,11 +241,6 @@ msgstr ""
 
 #. type: Plain text
 #: eeschema_automatic_classification_annotation.adoc:44
-#, fuzzy
-#| msgid ""
-#| "Use first free number in schematic: components are annotated from 1 (for "
-#| "each reference prefix). If a previous annotation exists, not yet in use "
-#| "numbers will be used."
 msgid ""
 "Use first free number in schematic: components are annotated from 1 (for "
 "each reference prefix). If a previous annotation exists, only unused numbers "
@@ -833,15 +789,12 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:126
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/add_text.png[icons/add_text_png]\n"
-#| "|Edit the fields of current component.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/text.png[icons/text.png]\n"
 "|Edit the fields of current component.\n"
 msgstr ""
-"|image:images/icons/add_text.png[icons/add_text_png]\n"
+"|image:images/icons/text.png[icons/text.png]\n"
 "|コンポーネントのフィールドを編集する。\n"
 
 #. type: delimited block |
@@ -1008,15 +961,12 @@ msgstr ""
 
 #. type: delimited block |
 #: eeschema_component_library_editor.adoc:188
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/add_text.png[icons/add_text_png]\n"
-#| "|Graphical text tool. Left-click to add a new graphical text item.\n"
+#, no-wrap
 msgid ""
 "|image:images/icons/text.png[icons/text.png]\n"
 "|Graphical text tool. Left-click to add a new graphical text item.\n"
 msgstr ""
-"|image:images/icons/add_text.png[icons/add_text_png]\n"
+"|image:images/icons/text.png[icons/text_png]\n"
 "|グラフィックテキストツール。（左クリックで新しいグラフィックテキストを追加します）\n"
 
 #. type: delimited block |
@@ -1333,18 +1283,14 @@ msgstr "新しいライブラリは自動的に現在のプロジェクトへは
 
 #. type: delimited block =
 #: eeschema_component_library_editor.adoc:323
-#, fuzzy
-#| msgid ""
-#| "You must add any new library you wish to use in a schematic to the list "
-#| "of project libraries in Eeschema using the component configuration dialog."
 msgid ""
 "You must add any new library you wish to use in a schematic to the list of "
 "project libraries in Eeschema using the <<manage-sym-lib-table,Symbol "
 "Library Table dialog>>."
 msgstr ""
-"回路図で使用したい新しいライブラリはすべて Eeschema の “設定” -> “コンポーネ"
-"ントライブラリ” でダイアログを開いて、コンポーネント・ライブラリ・ファイルの"
-"リストへ追加しなければなりません。"
+"回路図で使用したい新しいライブラリはすべて Eeschema の “設定” -> “シンボル ラ"
+"イブラリを管理” でダイアログを開いて、シンボル ライブラリ ファイルのリストへ"
+"追加しなければなりません。"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:332
@@ -1889,21 +1835,15 @@ msgstr "グラフィックタイプのテキスト要素"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:519
-#, fuzzy
-#| msgid ""
-#| "The image:images/icons/add_text.png[icons/add_text_png] allows for the "
-#| "creation of graphical text. Graphical text is always readable, even when "
-#| "the component is mirrored. Please note that graphical text items are not "
-#| "fields."
 msgid ""
 "The image:images/icons/text.png[icons/text.png] allows for the creation of "
 "graphical text. Graphical text is always readable, even when the component "
 "is mirrored. Please note that graphical text items are not fields."
 msgstr ""
-"アイコン image:images/icons/add_text.png[icons/add_text_png] により、グラ"
-"フィックタイプのテキストを作成がすることができます。グラフィックタイプのテキ"
-"ストはコンポーネントが反転 (mirrored) しても影響されず常に読むことができま"
-"す。グラフィックタイプのテキストはフィールドではないことに注意しましょう。"
+"アイコン image:images/icons/text.png[icons/text_png] により、グラフィックタイ"
+"プのテキストを作成がすることができます。グラフィックタイプのテキストはコン"
+"ポーネントが反転 (mirrored) しても影響されず常に読むことができます。グラ"
+"フィックタイプのテキストはフィールドではないことに注意しましょう。"
 
 #. type: Title ===
 #: eeschema_component_library_editor.adoc:521
@@ -2561,19 +2501,14 @@ msgstr "images/ja/eeschema_libedit_field_context_menu.png"
 
 #. type: Plain text
 #: eeschema_component_library_editor.adoc:752
-#, fuzzy
-#| msgid ""
-#| "To edit undefined fields, add new fields, or delete optional fields image:"
-#| "images/icons/add_text.png[icons/add_text_png] on the main tool bar to "
-#| "open the field properties dialog shown below."
 msgid ""
 "To edit undefined fields, add new fields, or delete optional fields image:"
 "images/icons/text.png[icons/text.png] on the main tool bar to open the field "
 "properties dialog shown below."
 msgstr ""
 "未定義フィールドの編集、新しいフィールドの追加、（追加された）オプション"
-"フィールドの削除を行うには、メインツールバーの  image:images/icons/add_text."
-"png[icons/add_text_png] で、次のコンポーネントプロパティ・ダイアログを開きま"
+"フィールドの削除を行うには、メインツールバーの  image:images/icons/text."
+"png[icons/text_png] で、以下に示すフィールドのプロパティ ダイアログを開きま"
 "す。"
 
 #. type: Named 'alt' AttributeList argument for macro 'image'
@@ -5867,38 +5802,30 @@ msgstr "ファイルメニュー"
 #. type: Target for macro image
 #: eeschema_main_top_menu.adoc:8
 #, fuzzy, no-wrap
-#| msgid "images/en/menu_bar.png"
 msgid "images/en/menu_file.png"
-msgstr "images/ja/menu_bar.png"
+msgstr "images/en/menu_file.png"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:13
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|image:images/icons/new_sch.png[new schematic icon]\n"
-#| "|Create a new schematic (only in standalone mode).\n"
+#, no-wrap
 msgid "|New |Close current schematic and start a new one (only in standalone mode).\n"
-msgstr ""
-"|image:images/icons/new_sch.png[new schematic icon]\n"
-"|新規回路図の作成（単独実行時のみ）\n"
+msgstr "| 新規 | 今の回路図を閉じて、新規回路図の作成（単独実行時のみ）。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:15
 #, no-wrap
 msgid "|Open |Load a schematic project (only in standalone mode).\n"
-msgstr ""
+msgstr "| 開く | 回路図プロジェクトを開く（単独実行時のみ）。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:17
-#, fuzzy, no-wrap
-#| msgid "|Open Recent |Open a list of recently opened files\n"
+#, no-wrap
 msgid "|Open Recent |Open a schematic project from the list of recently opened files (only in standalone mode).\n"
-msgstr "| 最近開いたファイル | 最近開いたファイルのリストから開く。（単独起動時のみ）\n"
+msgstr "| 最近開いたファイル | 最近開いた回路図ファイルのリストから開く。（単独実行時のみ）\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:19
-#, fuzzy, no-wrap
-#| msgid "|Append Schematic Sheet |Insert the contents of another sheet into the current one\n"
+#, no-wrap
 msgid "|Append Schematic Sheet |Insert the contents of another sheet into the current one.\n"
 msgstr "| 回路図シートから追加 | 現在の回路図へ別のシートの内容を追加する。\n"
 
@@ -5906,32 +5833,25 @@ msgstr "| 回路図シートから追加 | 現在の回路図へ別のシート�
 #: eeschema_main_top_menu.adoc:21
 #, no-wrap
 msgid "|Import Non-Kicad Schematic File |Imports a schematic project saved in another file format.\n"
-msgstr ""
+msgstr "| KiCad 以外の回路図ファイルをインポート | 異なるフォーマットで保存された回路図プロジェクトをインポートします。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:23
-#, fuzzy, no-wrap
-#| msgid "|Save Schematic Project |Save current sheet and all its hierarchy.\n"
+#, no-wrap
 msgid "|Save |Save current sheet and all its subsheets.\n"
-msgstr "| 回路図プロジェクトの保存 | 現在のシートと全ての階層を保存する。\n"
+msgstr "| 保存 | 現在のシートと全ての階層を保存する。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:25
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|Save Current Sheet Only |Save current sheet, but not others in a\n"
-#| "hierarchy.\n"
+#, no-wrap
 msgid "|Save Current Sheet |Save only the current sheet, but not others in the project.\n"
-msgstr ""
-"| 現在のシートのみ保存 | 階層の他のシートを除く現在のシートを\n"
-"保存する。\n"
+msgstr "| 現在のシートを保存 | プロジェクト内の現在のシートだけを保存する。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:27
-#, fuzzy, no-wrap
-#| msgid "|Save Current Sheet As... |Save current sheet with a new name.\n"
+#, no-wrap
 msgid "|Save Current Sheet As... |Save the current sheet under a new name.\n"
-msgstr "| 名前を付けて保存 | 名前を付けて現在のシートを保存。（単独起動時のみ）\n"
+msgstr "| 名前を付けて現在のシートを保存 | 名前を付けて現在のシートを保存。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:29
@@ -5941,10 +5861,9 @@ msgstr "| ページ設定 | ページの寸法とタイトルブロックを設�
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:31
-#, fuzzy, no-wrap
-#| msgid "|Print |Print schematic hierarchy (See also chapter <<plot-and-print,Plot and Print>>).\n"
+#, no-wrap
 msgid "|Print |Print schematic project (See also chapter <<plot-and-print,Plot and Print>>).\n"
-msgstr "| 印刷 | 印刷メニューにアクセスする（ <<plot-and-print,プロットと印刷>> の章を参照）。\n"
+msgstr "| 印刷 | 回路図を印刷する（ <<plot-and-print,プロットと印刷>> の章を参照）。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:33
@@ -5956,7 +5875,7 @@ msgstr "| プロット | Postscript HPGL あるいは SVF フォーマットで�
 #: eeschema_main_top_menu.adoc:35
 #, no-wrap
 msgid "|Close |Terminate the application.\n"
-msgstr ""
+msgstr "| 閉じる | アプリケーションを終了する。\n"
 
 #. type: Named 'alt' AttributeList argument for macro 'image'
 #: eeschema_main_top_menu.adoc:38 eeschema_main_top_menu.adoc:40
@@ -5967,9 +5886,8 @@ msgstr "設定メニュー"
 #. type: Target for macro image
 #: eeschema_main_top_menu.adoc:40
 #, fuzzy, no-wrap
-#| msgid "images/en/menu_bar.png"
 msgid "images/en/menu_preferences.png"
-msgstr "images/ja/menu_bar.png"
+msgstr "images/en/menu_preferences.png"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:50
@@ -5982,41 +5900,42 @@ msgid ""
 "|Icons Options | Icons visibility settings.\n"
 "|Import and Export | Transfer preferences to/from file.\n"
 msgstr ""
+"| シンボル ライブラリ テーブルを管理 | シンボル ライブラリの追加や削除を行います。\n"
+"| パスを設定 | 検索に利用するパスを設定します。\n"
+"| 全般 オプション | 詳細設定です（単位、グリッドサイズ、フィールド名、など）。\n"
+"| 言語設定 | インターフェースの言語を選択します。\n"
+"| アイコンオプション | アイコンの見た目を設定します。\n"
+"| インポートとエクスポート | 設定項目のファイルへの抽出や、ファイルからの読み取りを行います。\n"
 
 #. type: Title ====
 #: eeschema_main_top_menu.adoc:53
-#, fuzzy, no-wrap
-#| msgid "Symbol library"
+#, no-wrap
 msgid "Manage Symbol Library Tables"
-msgstr "シンボルライブラリ"
+msgstr "シンボル ライブラリ テープルの管理"
 
 #. type: Named 'alt' AttributeList argument for macro 'image'
 #: eeschema_main_top_menu.adoc:55
-#, fuzzy, no-wrap
-#| msgid "Symbol library"
+#, no-wrap
 msgid "Symbol Library Tables"
-msgstr "シンボルライブラリ"
+msgstr "シンボル ライブラリ テーブル"
 
 #. type: Target for macro image
 #: eeschema_main_top_menu.adoc:55
 #, fuzzy, no-wrap
-#| msgid "images/en/options.png"
 msgid "images/en/options_symbol_lib.png"
-msgstr "images/ja/options.png"
+msgstr "images/en/options_symbol_lib.png"
 
 #. type: Plain text
 #: eeschema_main_top_menu.adoc:59
 msgid ""
 "Eeschema uses two library tables to store the list of available symbol "
 "libraries, which differ by the scope:"
-msgstr ""
+msgstr "Eeschemaはスコープの異なる2種類のシンボル ライブラリを利用します。"
 
 #. type: Plain text
 #: eeschema_main_top_menu.adoc:61
-#, fuzzy
-#| msgid "Global labels"
 msgid "Global Libraries"
-msgstr "グローバルラベル"
+msgstr "グローバル ライブラリ"
 
 #. type: Plain text
 #: eeschema_main_top_menu.adoc:65
@@ -6025,11 +5944,14 @@ msgid ""
 "project.  They are saved in *sym-lib-table* in your home directory (exact "
 "path is dependent on the operating system; check the path above the table)."
 msgstr ""
+"グローバル ライブラリ テーブルで管理されるシンボルは、全てのプロジェクトで利"
+"用できます。このリストは、ホームディレクトリの *sym-lib-table* に保存されます"
+"（OSによってパスは異なります）。"
 
 #. type: Plain text
 #: eeschema_main_top_menu.adoc:67
 msgid "Project Specific Libraries"
-msgstr ""
+msgstr "プロジェクト固有のライブラリ"
 
 #. type: Plain text
 #: eeschema_main_top_menu.adoc:71
@@ -6038,6 +5960,9 @@ msgid ""
 "currently opened project. They are saved in *sym-lib-table* file in the "
 "project directory (check the path above the table)."
 msgstr ""
+"プロジェクト固有のライブラリ テーブルで管理されるシンボルは、そのテーブルに紐"
+"づくプロジェクトで利用できます。テーブルは *sym-lib-table* ファイルとして、プ"
+"ロジェクトのディレクトリに保存されます。"
 
 #. type: Plain text
 #: eeschema_main_top_menu.adoc:74
@@ -6045,12 +5970,14 @@ msgid ""
 "You can view either list by clicking on \"Global Libraries\" or \"Project "
 "Specific Libraries\" tab below the library table."
 msgstr ""
+"下に示す回路図ライブラリ テーブルのタブを切り替えることで、 \"グローバル ライ"
+"ブラリ\" か \"プロジェクト固有のライブラリ\"  を閲覧できます。"
 
 #. type: Title =====
 #: eeschema_main_top_menu.adoc:75
 #, no-wrap
 msgid "Add a new library"
-msgstr ""
+msgstr "ライブラリを追加"
 
 #. type: Plain text
 #: eeschema_main_top_menu.adoc:81
@@ -6060,13 +5987,16 @@ msgid ""
 "The selected library will be added to the currently opened library table "
 "(Global/Project Specific)."
 msgstr ""
+"*ライブラリを参照..* ボタンをクリックしてファイルを選択するか、 *ライブラリを"
+"追加* をクリックしてライブラリファイルへのパスを入力することで、ライブラリを"
+"追加できます。選択したライブラリは、現在のプロジェクトの（グローバルもしくは"
+"プロジェクト固有の）ライブラリテーブルに追加されます。"
 
 #. type: Title =====
 #: eeschema_main_top_menu.adoc:82
-#, fuzzy, no-wrap
-#| msgid "Symbol library"
+#, no-wrap
 msgid "Remove a library"
-msgstr "シンボルライブラリ"
+msgstr "ライブラリを削除"
 
 #. type: Plain text
 #: eeschema_main_top_menu.adoc:86
@@ -6074,18 +6004,20 @@ msgid ""
 "Remove a library by selecting one or more libraries and clicking *Remove "
 "Library* button."
 msgstr ""
+"一つか複数のライブラリをクリックし *ライブラリを削除* ボタンをクリックするこ"
+"とで、ライブラリを削除できます。"
 
 #. type: Title =====
 #: eeschema_main_top_menu.adoc:87
-#, fuzzy, no-wrap
-#| msgid "Library settings"
+#, no-wrap
 msgid "Library properties"
-msgstr "Library settings"
+msgstr "ライブラリのプロパティ"
 
 #. type: Plain text
 #: eeschema_main_top_menu.adoc:90
 msgid "Each row in the table stores several fields describing a library:"
 msgstr ""
+"テーブルの各行は、いくつかのフィールドでライブラリの情報を表示しています :"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:100
@@ -6099,11 +6031,16 @@ msgid ""
 "| Options| Stores library specific options, if used by plugin.\n"
 "| Description| Briefly characterizes the library contents.\n"
 msgstr ""
+"| アクティブ | ライブラリの有効/無効を。この機能は、一時的にロードするライブラリを減らしたいときに有効です。\n"
+"| 別名（ニックネーム） | 短く、ユニークな別名を、シンボルに割り当てられます。シンボルには '< ライブラリのニックネーム >:< シンボル名>' という文字列が割り当てられます。\n"
+"| ライブラリのパス| ライブラリの場所を示します。\n"
+"| プラグインの種類 | ライブラリのファイルフォーマットを決めます。\n"
+"| オプション | プラグインで利用する場合、ライブラリ固有のオプションを保持します。\n"
+"| 説明 | ライブラリについて完結に説明します。\n"
 
 #. type: Title ====
 #: eeschema_main_top_menu.adoc:104
-#, fuzzy, no-wrap
-#| msgid "General options"
+#, no-wrap
 msgid "General Options"
 msgstr "全般オプション"
 
@@ -6111,113 +6048,86 @@ msgstr "全般オプション"
 #: eeschema_main_top_menu.adoc:107
 #, no-wrap
 msgid "Display"
-msgstr ""
+msgstr "表示"
 
 #. type: Named 'alt' AttributeList argument for macro 'image'
 #: eeschema_main_top_menu.adoc:109
-#, fuzzy, no-wrap
-#| msgid "Library settings"
+#, no-wrap
 msgid "Display settings"
-msgstr "Library settings"
+msgstr "表示設定"
 
 #. type: Target for macro image
 #: eeschema_main_top_menu.adoc:109
 #, fuzzy, no-wrap
-#| msgid "images/en/options.png"
 msgid "images/en/options_display.png"
-msgstr "images/ja/options.png"
+msgstr "images/en/options_display.png"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:114
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|Grid Size: a|\n"
-#| "Grid size selection.\n"
+#, no-wrap
 msgid "|Grid Size| Grid size selection.\n"
-msgstr ""
-"| グリッドサイズ: |\n"
-"グリッドサイズの選択。\n"
+msgstr "| グリッドサイズ | グリッドサイズを選べます。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:117
-#, fuzzy, no-wrap
-#| msgid ""
-#| "**It is recommended to work with normal grid (0.050 inches or 1,27 mm)**. __Smaller\n"
-#| "grids are used for component building__.\n"
+#, no-wrap
 msgid ""
 "It is *recommended* to work with normal grid (0.050 inches or 1,27 mm). Smaller\n"
 "grids are used for component building.\n"
-msgstr ""
-"**通常グリッド(0.050 インチあるいは 1.27mm)での作業を推奨** __より\n"
-"細かいグリッドはコンポーネント作成で使用__ \n"
+msgstr "通常グリッド(0.050 インチあるいは 1.27mm)での作業を *推奨します。* より細かいグリッドはコンポーネント作成で使用します。 \n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:119
-#, fuzzy, no-wrap
-#| msgid "|Default bus width: |Pen size used to draw buses.\n"
+#, no-wrap
 msgid "|Bus thickness |Pen size used to draw buses.\n"
-msgstr "| デフォルトのバス線幅: | ペンのサイズはバスを描画するために使用される。\n"
+msgstr "| バス線幅 | バスを描画するペンのサイズです。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:122
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|Default line width: |Pen size used to draw objects that do not have a\n"
-#| "specified pen size.\n"
+#, no-wrap
 msgid ""
 "|Line thickness |Pen size used to draw objects that do not have a\n"
 "specified pen size.\n"
-msgstr ""
-"| セグメント幅の変更: | ペンのサイズはペンサイズが指定されていないオブジェクトを\n"
-"描画するために使用される。\n"
+msgstr "| 線幅 | ペンのサイズが指定されていないオブジェクトを描画するときに利用されます。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:125
-#, fuzzy, no-wrap
-#| msgid "|Part id notation: |Style of suffix that is used to denote component parts (U1A, U1.A, U1-1, etc.)\n"
+#, no-wrap
 msgid ""
 "|Part ID notation |Style of suffix that is used to denote symbol units (U1A,\n"
 "U1.A, U1-1, etc.)\n"
-msgstr "| 部品 ID の表記方法: | コンポーネント名を示すために使われる接尾辞の形式 (U1A, U1.A, U1-1, etc.)\n"
+msgstr "| パーツ ID の表記方法 | コンポーネント名を示すために使われる接尾辞の形式です。 (U1A, U1.A, U1-1, etc.)\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:127
 #, no-wrap
 msgid "|Icon scale| Adjust toolbar icons size.\n"
-msgstr ""
+msgstr "| アイコン スケール | ツールバーのアイコンのサイズを調整できます。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:129
 #, no-wrap
 msgid "|Show Grid | Grid visibility setting.\n"
-msgstr ""
+msgstr "| グリッドを表示 | グリッドの表示を切り替えれます。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:133
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|Allow buses and wires to be placed in H or V orientation only a|\n"
-#| "If checked, buses and wires can only be vertical or horizontal.\n"
+#, no-wrap
 msgid ""
 "|Restrict buses and wires to H and V orientation| If checked, buses and\n"
 "wires are drawn only with vertical or horizontal lines.\n"
 "Otherwise buses and wires can be placed at any orientation.\n"
 msgstr ""
-"| バス、配線の 90 度入力 | \n"
-"チェックがある場合，バスや配線は垂直または水平になる。\n"
+"| バス、配線を90度入力に制限 | チェックがある場合，バスや配線は垂直または水平になります。\n"
+"そうでなければ、バス、配線はどのような角度にも配置されます。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:136
-#, fuzzy, no-wrap
-#| msgid ""
-#| "|Show hidden pins: |Display invisible (or __hidden__) pins, typically power pins. If checked,\n"
-#| "allows the display of power pins.\n"
+#, no-wrap
 msgid ""
 "|Show hidden pins: |Display invisible (or __hidden__) pins, typically\n"
 "power pins.\n"
-msgstr ""
-"| 非表示ピンの表示: | 非表示 ( または __hidden__) ピンを表示。チェックがある場合、\n"
-"電源ピンも表示される。\n"
+msgstr "| 非表示ピンの表示 | 非表示 ( または __hidden__) ピンを表示。チェックがある場合、電源ピンも表示されます。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:138
@@ -6231,13 +6141,13 @@ msgstr "| ページの境界を表示 | チェックがある場合、画面上�
 msgid ""
 "|Footprint previews in symbol chooser| Displays a footprint preview frame and\n"
 "footprint selector when placing a new symbol.\n"
-msgstr ""
+msgstr "| シンボルの選択中にフットプリントをプレビュー | シンボルを選択すると、フットプリントのプレビューとフットプリントの選択肢が表示されます。\n"
 
 #. type: delimited block |
 #: eeschema_main_top_menu.adoc:143
 #, no-wrap
 msgid "*Note:* it may cause problems or delays, use at your own risk.\n"
-msgstr ""
+msgstr "*メモ:* 問題の発生や処理が遅くなる可能性があるので、利用は自己責任でお願いします。\n"
 
 #. type: Title =====
 #: eeschema_main_top_menu.adoc:146


### PR DESCRIPTION
`src/eeschema/po/ja.po` の一部を翻訳しました。

https://github.com/kicad-jp/kicad-doc/issues/89 で共有していただいた通り、翻訳の過程で下記の画像が更新されているのを認識しました。

- menu_bar.png -> menu_file.png, meny_preferences.png
- options.png -> options_symbol_lib.png, options_display.png

自分の環境（ubuntu）だと、英語版のスクリーンショットのような楽しい画像にならない（各メニューのアイコンやOK Cancelアイコンが出ない）ので、jp版の画像は作らず、英語版を割り当て、 `fuzzy` フラグを立てています。
どこかのタイミングで、アイコンが表示される環境の日本語版スクリーンショットを割り当てられればと思います。

確認をお願いします。